### PR TITLE
fix: DataModule data_path -> normalized_data_path compat (wind-forecasting main)

### DIFF
--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -115,7 +115,7 @@ class MLForecast(WindForecast):
                 f"Loaded checkpoint from {checkpoint_path}"
             )  # with hparams: {checkpoint_hparams}")
             self.data_module = DataModule(
-                data_path=self.model_config["dataset"]["data_path"],
+                normalized_data_path=self.model_config["dataset"]["data_path"],
                 n_splits=self.model_config["dataset"]["n_splits"],
                 continuity_groups=None,
                 train_split=(

--- a/whoc/wind_forecast/run_forecaster_validation.py
+++ b/whoc/wind_forecast/run_forecaster_validation.py
@@ -1060,7 +1060,7 @@ if __name__ == "__main__":
     joint_cgs = set()
     for mcnf in model_configs:
         data_module = DataModule(
-            data_path=mcnf["dataset"]["data_path"],
+            normalized_data_path=mcnf["dataset"]["data_path"],
             normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
             use_normalization=False,
             n_splits=1,  # model_config["dataset"]["n_splits"],

--- a/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
@@ -1,0 +1,280 @@
+"""FAITHFUL verification: predict_distr vs predict_sample on identical real input.
+
+Doubts being tested empirically:
+  1. Does predict_distr produce a non-empty df with loc_*/sd_* columns?  (structural)
+  2. Are the sd_* values HEALTHY (not collapsed to ~0)?                  (value sanity)
+  3. Does predict_distr's sd_* MATCH predict_sample's empirical sample
+     std on the SAME input?  predict_sample is the known-good oracle —
+     job 16929835 produced healthy spread (F^-1 width 2.09) through it.
+
+Faithful to the real pipeline (run_forecaster_validation.py:1062-1162):
+  - data: the cached test split, DENORMALIZED (raw m/s), 15s, all-turbine
+  - measurements_timedelta = 15s  (SBATCH used --simulation_timestep 15)
+  - input format: wide, turbine-suffixed columns (ws_horz_wtNNN ...)
+
+If predict_sample stays healthy but predict_distr collapses -> real predict_distr bug.
+If both collapse -> input still wrong.  If both healthy and ~equal -> predict_distr verified.
+"""
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("faithful")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+# The cached test split the real validation harness uses — denormalized, 15s, all-turbine.
+TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        r = fn()
+        STAGES.append((name, "PASS", ""))
+        return r
+    except Exception as e:
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, traceback.format_exc())
+        raise
+
+
+def main():
+    from whoc.wind_forecast.ml_forecast import MLForecast
+    from wind_forecasting.preprocessing.data_module import DataModule
+
+    with open(MODEL_CONFIG) as f:
+        mcnf = yaml.safe_load(f)
+
+    measurements_timedelta = pd.Timedelta(seconds=15)  # SBATCH --simulation_timestep 15
+    ptd = pd.Timedelta(seconds=mcnf["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=mcnf["dataset"]["context_length"])
+
+    # --- Stage 1: build the test_data DataModule exactly like run_forecaster_validation.py:1062
+    def build_test_dm():
+        dm = DataModule(
+            normalized_data_path=mcnf["dataset"]["data_path"],
+            normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
+            use_normalization=False,                       # DENORMALIZED — raw m/s
+            n_splits=1,
+            continuity_groups=None,
+            train_split=(1.0 - mcnf["dataset"]["val_split"] - mcnf["dataset"]["test_split"]),
+            val_split=mcnf["dataset"]["val_split"],
+            test_split=mcnf["dataset"]["test_split"],
+            prediction_length=mcnf["dataset"]["prediction_length"],
+            context_length=mcnf["dataset"]["context_length"],
+            target_prefixes=["ws_horz", "ws_vert"],
+            feat_dynamic_real_prefixes=["nd_cos", "nd_sin"],
+            freq=f"{int(measurements_timedelta.total_seconds())}s",   # "15s"
+            target_suffixes=mcnf["dataset"]["target_turbine_ids"],
+            per_turbine_target=False,                      # all-turbine wide format
+            as_lazyframe=True,
+            dtype=pl.Float32,
+        )
+        dm.generate_splits(save=True, reload=False, splits=["test"])
+        log.info("target_cols[:4]=%s ... (%d total)", dm.target_cols[:4], len(dm.target_cols))
+        log.info("feat_dynamic_real_cols[:2]=%s ... (%d total)",
+                 dm.feat_dynamic_real_cols[:2], len(dm.feat_dynamic_real_cols))
+        return dm
+
+    test_dm = stage("Build test DataModule + generate_splits(test)", build_test_dm)
+
+    # --- Stage 2: load + rename the test split into the wide format predict_* expect
+    def build_test_data():
+        test_df = test_dm.datasets["test"]
+        if hasattr(test_df, "collect"):
+            test_df = test_df.collect()
+        rename_map = {
+            **{f"target_{i}": c for i, c in enumerate(test_dm.target_cols)},
+            **{f"feat_dynamic_real_{i}": c
+               for i, c in enumerate(test_dm.feat_dynamic_real_cols)},
+        }
+        test_df = (test_df.rename(rename_map)
+                          .with_columns(continuity_group=pl.col("item_id")
+                                        .str.extract(r"SPLIT(\d+)").cast(int)))
+        log.info("test_data rows=%d, n continuity groups=%d",
+                 test_df.height, test_df["continuity_group"].n_unique())
+        return test_df
+
+    test_data = stage("Load + rename cached test split", build_test_data)
+
+    # --- Stage 3: construct MLForecast
+    def build_forecaster():
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=max(pd.Timedelta(5, unit="s"), measurements_timedelta),
+            prediction_timedelta=ptd,
+            context_timedelta=ctd,
+            fmodel=None,
+            true_wind_field=None,
+            tid2idx_mapping={str(s): i for i, s in enumerate(test_dm.target_suffixes)},
+            turbine_signature=r"\d+",
+            use_tuned_params=True,
+            kwargs=dict(model_key="tactis", model_checkpoint=CHECKPOINT,
+                        optuna_storage=None, study_name=None,
+                        model_config=mcnf, resample=False),
+            target_turbine_indices=None,
+        )
+
+    forecaster = stage("Construct MLForecast", build_forecaster)
+    stage("forecaster.reset()", lambda: forecaster.reset())
+
+    # --- Stage 4: pick a continuity group + build a context window
+    def pick_context():
+        n_ctx = forecaster.n_context
+        sizes = (test_data.group_by("continuity_group").agg(pl.len().alias("n"))
+                 .sort("n", descending=True))
+        cg = sizes["continuity_group"][0]
+        log.info("largest continuity_group=%s has %d rows (n_context=%d)",
+                 cg, sizes["n"][0], n_ctx)
+        sub = (test_data.filter(pl.col("continuity_group") == cg)
+                        .sort("time")
+                        .head(n_ctx + 20)
+                        .drop("continuity_group"))
+        # drop non-measurement columns predict_* don't expect
+        for extra in ("item_id", "feat_static_cat", "prediction_timedelta"):
+            if extra in sub.columns:
+                sub = sub.drop(extra)
+        current_time = sub["time"][-1]
+        log.info("context rows=%d, current_time=%s, cols sample=%s",
+                 sub.height, current_time, sub.columns[:5])
+        return sub, current_time
+
+    ctx, current_time = stage("Pick continuity group + context window", pick_context)
+
+    # --- Stage 5: predict_sample (ORACLE) on this exact input
+    def run_sample():
+        pred = forecaster.predict_sample(ctx, current_time, n_samples=200)
+        log.info("predict_sample -> rows=%d, cols=%d, n_samples=%d, n_times=%d",
+                 pred.height, len(pred.columns),
+                 pred["sample"].n_unique(), pred["time"].n_unique())
+        return pred
+
+    samp = stage("predict_sample (oracle)", run_sample)
+
+    # --- Stage 6: predict_distr on the SAME input
+    def run_distr():
+        pred = forecaster.predict_distr(ctx, current_time)
+        assert pred is not None and pred.height > 0, "predict_distr returned empty"
+        log.info("predict_distr -> rows=%d, cols=%d, n_times=%d",
+                 pred.height, len(pred.columns), pred["time"].n_unique())
+        return pred
+
+    distr = stage("predict_distr (under test)", run_distr)
+
+    # --- Stage 7: COMPARE oracle vs predict_distr
+    def compare():
+        # turbine-component columns present in the sample output
+        wt_cols = [c for c in samp.columns
+                   if c.startswith("ws_horz_") or c.startswith("ws_vert_")]
+        # empirical std from predict_sample, per (time, turbine-component)
+        emp = (samp.group_by("time")
+                   .agg([pl.col(c).std().alias(f"emp_sd_{c}") for c in wt_cols])
+                   .sort("time"))
+        # align times via JOIN (not set+is_in — polars is_in fails silently on
+        # datetime-precision mismatch). Cast both to ns first so the join keys match.
+        d = distr.with_columns(pl.col("time").cast(pl.Datetime("ns"))).sort("time")
+        e = emp.with_columns(pl.col("time").cast(pl.Datetime("ns"))).sort("time")
+        joined = d.join(e, on="time", how="inner").sort("time")
+        log.info("common prediction timestamps (via join): %d", joined.height)
+        assert joined.height > 0, "no overlapping timestamps between sample and distr"
+
+        # collect all sd_* from distr and emp_sd_* from oracle, matched by column
+        ratios, distr_sds, oracle_sds = [], [], []
+        for c in wt_cols:
+            sd_col = f"sd_{c}"
+            emp_col = f"emp_sd_{c}"
+            if sd_col not in joined.columns or emp_col not in joined.columns:
+                continue
+            dv = joined[sd_col].to_numpy().astype(float)
+            ev = joined[emp_col].to_numpy().astype(float)
+            distr_sds.append(dv)
+            oracle_sds.append(ev)
+            mask = ev > 1e-9
+            ratios.append(dv[mask] / ev[mask])
+
+        distr_sds = np.concatenate(distr_sds)
+        oracle_sds = np.concatenate(oracle_sds)
+        ratios = np.concatenate(ratios) if ratios else np.array([np.nan])
+
+        log.info("-" * 60)
+        log.info("predict_distr  sd_*  : median=%.5f  mean=%.5f  p10=%.5f  p90=%.5f  max=%.5f",
+                 np.median(distr_sds), distr_sds.mean(),
+                 np.quantile(distr_sds, .1), np.quantile(distr_sds, .9), distr_sds.max())
+        log.info("predict_sample emp_sd: median=%.5f  mean=%.5f  p10=%.5f  p90=%.5f  max=%.5f",
+                 np.median(oracle_sds), oracle_sds.mean(),
+                 np.quantile(oracle_sds, .1), np.quantile(oracle_sds, .9), oracle_sds.max())
+        log.info("ratio distr/oracle   : median=%.4f  mean=%.4f  (1.0 == perfect match)",
+                 np.median(ratios), np.mean(ratios))
+        log.info("-" * 60)
+
+        # VERDICTS
+        oracle_healthy = np.median(oracle_sds) > 0.1   # m/s — known-good path should be wide
+        distr_healthy = np.median(distr_sds) > 0.1
+        distr_matches_oracle = 0.5 < np.median(ratios) < 2.0
+
+        log.info("oracle (predict_sample) healthy (median sd > 0.1 m/s): %s", oracle_healthy)
+        log.info("predict_distr healthy (median sd > 0.1 m/s):           %s", distr_healthy)
+        log.info("predict_distr matches oracle (0.5 < ratio < 2.0):      %s", distr_matches_oracle)
+
+        return dict(
+            distr_sd_median=float(np.median(distr_sds)),
+            oracle_sd_median=float(np.median(oracle_sds)),
+            ratio_median=float(np.median(ratios)),
+            oracle_healthy=bool(oracle_healthy),
+            distr_healthy=bool(distr_healthy),
+            distr_matches_oracle=bool(distr_matches_oracle),
+        )
+
+    result = stage("COMPARE predict_distr vs predict_sample oracle", compare)
+    return result
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        result = main()
+    except Exception:
+        ok = False
+        result = None
+
+    print("\n" + "=" * 70)
+    print("FAITHFUL VERIFICATION REPORT — predict_distr vs predict_sample oracle")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        print(f"  [{status}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and result:
+        print(f"predict_distr  sd median : {result['distr_sd_median']:.5f} m/s")
+        print(f"predict_sample sd median : {result['oracle_sd_median']:.5f} m/s  (oracle)")
+        print(f"ratio (distr/oracle)     : {result['ratio_median']:.4f}")
+        print("-" * 70)
+        if result["oracle_healthy"] and result["distr_healthy"] and result["distr_matches_oracle"]:
+            print("RESULT: predict_distr VERIFIED — healthy spread, matches the oracle.")
+            sys.exit(0)
+        elif result["oracle_healthy"] and not result["distr_healthy"]:
+            print("RESULT: REAL predict_distr BUG — oracle is healthy but predict_distr collapsed.")
+            sys.exit(2)
+        elif not result["oracle_healthy"]:
+            print("RESULT: INCONCLUSIVE — even the oracle collapsed; input still not faithful.")
+            sys.exit(3)
+        else:
+            print("RESULT: predict_distr runs + healthy but does NOT match oracle — investigate scaling.")
+            sys.exit(4)
+    else:
+        print("RESULT: harness failed before comparison — see failed stage above.")
+        sys.exit(1)

--- a/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
@@ -33,8 +33,7 @@ sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
 
 MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
 CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
-# The cached test split the real validation harness uses — denormalized, 15s, all-turbine.
-TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+# Note: the cached test split is loaded via the DataModule (build_test_dm), not a direct path.
 
 STAGES = []
 

--- a/whoc/wind_forecast/tests/verify_predict_distr_phase0i_g.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_phase0i_g.py
@@ -1,0 +1,210 @@
+"""Verify MLForecast.predict_distr works end-to-end with the Phase 0i-G checkpoint.
+
+Phase 0i-G validation (job 16929835) exercised predict_sample. The controller
+simulation path (simulate_case_studies) uses predict_distr instead, which is a
+separate code path that emits loc_* / sd_* columns. This script constructs the
+real MLForecast object the same way run_forecaster_validation.py does, feeds it
+a real slice of context data, calls predict_distr, and audits the output.
+
+Run on a GPU node:
+    python verify_predict_distr_phase0i_g.py
+"""
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("verify")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+DATA_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/preprocessing/preprocessing_inputs_awaken_STORM.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        result = fn()
+        STAGES.append((name, "PASS", ""))
+        return result
+    except Exception as e:
+        tb = traceback.format_exc()
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, tb)
+        raise
+
+
+def main():
+    # fmodel is a stored dataclass field only — never referenced by MLForecast.__init__
+    # or predict_distr — so we pass None and skip the FLORIS dependency entirely.
+    from whoc.wind_forecast.ml_forecast import MLForecast
+
+    with open(MODEL_CONFIG) as f:
+        model_config = yaml.safe_load(f)
+    with open(DATA_CONFIG) as f:
+        data_config = yaml.safe_load(f)
+
+    # --- replicate run_forecaster_validation.py turbine wiring ---
+    sig = data_config.get("turbine_signature")
+    if isinstance(sig, list):
+        turbine_signature = sig[0] if len(sig) == 1 else r"\d+"
+    else:
+        turbine_signature = sig or r"\d+"
+
+    tmap = data_config.get("turbine_mapping")
+    if isinstance(tmap, list) and tmap:
+        keys = list(tmap[0].keys()) if len(data_config.get("turbine_signature", [1])) == 1 else list(tmap[0].values())
+        tid2idx_mapping = {str(k): i for i, k in enumerate(keys)}
+    else:
+        # fallback: derive from the data parquet's ws_horz_* columns
+        cols = pl.scan_parquet(model_config["dataset"]["data_path"]).collect_schema().names()
+        wt_ids = [c.replace("ws_horz_", "") for c in cols if c.startswith("ws_horz_")]
+        tid2idx_mapping = {str(k): i for i, k in enumerate(wt_ids)}
+    log.info("turbine_signature=%r, n turbines in tid2idx=%d", turbine_signature, len(tid2idx_mapping))
+
+    measurements_timedelta = pd.Timedelta(seconds=15)
+    controller_timedelta = max(pd.Timedelta(5, unit="s"), measurements_timedelta)
+    ptd = pd.Timedelta(seconds=model_config["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=model_config["dataset"]["context_length"])
+
+    def build_forecaster():
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=controller_timedelta,
+            prediction_timedelta=ptd,
+            context_timedelta=ctd,
+            fmodel=None,
+            true_wind_field=None,
+            tid2idx_mapping=tid2idx_mapping,
+            turbine_signature=turbine_signature,
+            use_tuned_params=True,
+            kwargs=dict(
+                model_key="tactis",
+                model_checkpoint=CHECKPOINT,
+                optuna_storage=None,
+                study_name=None,
+                model_config=model_config,
+                resample=False,
+            ),
+            target_turbine_indices=None,
+        )
+
+    forecaster = stage("Construct MLForecast (loads Phase 0i-G checkpoint)", build_forecaster)
+
+    stage("forecaster.reset()", lambda: forecaster.reset())
+
+    # --- build a real context window of historic measurements ---
+    def load_context():
+        # LAZY scan — never materialize the full multi-GB parquet.
+        # IMPORTANT: awaken_processed_unsmoothed_normalized.parquet is at 1-SECOND
+        # resolution, but the model was trained on 15-SECOND data (data_module.freq).
+        # predict_distr / _generate_test_data expect input already at the model freq.
+        # So we resample 1s -> 15s by mean (matches the training preprocessing)
+        # before handing it over — exactly what the real validation pipeline feeds in.
+        n_ctx = forecaster.n_context  # 80 steps at 15s
+        model_freq = str(forecaster.data_module.freq)  # "15s"
+        lf = pl.scan_parquet(model_config["dataset"]["data_path"])
+        first_cg = lf.select("continuity_group").head(1).collect()["continuity_group"][0]
+        # grab enough 1s rows to build n_ctx+margin 15s rows
+        n_raw = (n_ctx + 25) * 15
+        raw = (lf.filter(pl.col("continuity_group") == first_cg)
+                 .sort("time")
+                 .head(n_raw)
+                 .collect()
+                 .drop("continuity_group"))
+        log.info("raw 1s rows pulled: %d (continuity_group=%s)", raw.height, first_cg)
+        # resample 1s -> model freq by mean
+        sub = (raw.sort("time")
+                  .group_by_dynamic("time", every=model_freq)
+                  .agg(pl.all().mean()))
+        if sub.height < n_ctx + 1:
+            raise RuntimeError(
+                f"after 1s->{model_freq} resample only {sub.height} rows, need >= {n_ctx + 1}"
+            )
+        # Mirror make_predictions' contract: predict_distr receives rows with
+        # time <= current_time, so current_time = the LAST resampled timestamp.
+        current_time = sub["time"][-1]
+        step = (sub["time"][1] - sub["time"][0])
+        log.info("resampled to %s: rows=%d, step=%s, n_context=%d, current_time=%s",
+                 model_freq, sub.height, step, n_ctx, current_time)
+        return sub, current_time
+
+    hist, current_time = stage("Load real context window", load_context)
+
+    # --- the actual test: call predict_distr ---
+    def run_predict_distr():
+        pred = forecaster.predict_distr(hist, current_time)
+        return pred
+
+    pred = stage("CALL predict_distr", run_predict_distr)
+
+    # --- audit the output ---
+    def audit():
+        assert pred is not None and pred.height > 0, "empty prediction"
+        cols = pred.columns
+        loc_cols = [c for c in cols if c.startswith("loc_")]
+        sd_cols = [c for c in cols if c.startswith("sd_")]
+        log.info("output rows=%d, cols=%d", pred.height, len(cols))
+        log.info("  loc_* columns: %d (e.g. %s)", len(loc_cols), loc_cols[:3])
+        log.info("  sd_*  columns: %d (e.g. %s)", len(sd_cols), sd_cols[:3])
+        assert len(sd_cols) > 0, "NO sd_* columns produced — controller would have no stddev input"
+        assert len(loc_cols) > 0, "NO loc_* columns produced"
+        # NaN / negativity / magnitude checks on sd_*
+        sd_arr = pred.select(sd_cols).to_numpy()
+        loc_arr = pred.select(loc_cols).to_numpy()
+        n_nan_sd = int(np.isnan(sd_arr).sum())
+        n_neg_sd = int((sd_arr < 0).sum())
+        n_nan_loc = int(np.isnan(loc_arr).sum())
+        log.info("  sd_* : NaN=%d, negative=%d, min=%.4f, median=%.4f, max=%.4f",
+                 n_nan_sd, n_neg_sd, np.nanmin(sd_arr), np.nanmedian(sd_arr), np.nanmax(sd_arr))
+        log.info("  loc_*: NaN=%d, min=%.4f, median=%.4f, max=%.4f",
+                 n_nan_loc, np.nanmin(loc_arr), np.nanmedian(loc_arr), np.nanmax(loc_arr))
+        assert n_nan_sd == 0, f"{n_nan_sd} NaN values in sd_* columns"
+        assert n_neg_sd == 0, f"{n_neg_sd} negative values in sd_* columns"
+        assert n_nan_loc == 0, f"{n_nan_loc} NaN values in loc_* columns"
+        # the prediction horizon should be prediction_length steps
+        log.info("  prediction timestamps: %d (expect ~%d)",
+                 pred["time"].n_unique(), int(ptd / measurements_timedelta))
+        return dict(rows=pred.height, loc_cols=len(loc_cols), sd_cols=len(sd_cols),
+                    sd_median=float(np.nanmedian(sd_arr)))
+
+    summary = stage("Audit predict_distr output", audit)
+    return summary
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        summary = main()
+    except Exception:
+        ok = False
+        summary = None
+
+    print("\n" + "=" * 70)
+    print("VERIFICATION REPORT — predict_distr on Phase 0i-G checkpoint")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        mark = "PASS" if status == "PASS" else "FAIL"
+        print(f"  [{mark}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and summary:
+        print(f"RESULT: predict_distr WORKS with Phase 0i-G.")
+        print(f"  output rows={summary['rows']}, loc_* cols={summary['loc_cols']}, "
+              f"sd_* cols={summary['sd_cols']}, sd median={summary['sd_median']:.4f}")
+        sys.exit(0)
+    else:
+        print("RESULT: predict_distr FAILED — see failed stage above.")
+        sys.exit(1)

--- a/whoc/wind_forecast/tests/verify_predict_distr_quantile_head.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_quantile_head.py
@@ -1,13 +1,13 @@
-"""Verify MLForecast.predict_distr works end-to-end with the Phase 0i-G checkpoint.
+"""Verify MLForecast.predict_distr works end-to-end with the quantile-head TACTiS-2 checkpoint.
 
-Phase 0i-G validation (job 16929835) exercised predict_sample. The controller
-simulation path (simulate_case_studies) uses predict_distr instead, which is a
-separate code path that emits loc_* / sd_* columns. This script constructs the
+The quantile-head model's validation (job 16929835) exercised predict_sample. The
+controller simulation path (simulate_case_studies) uses predict_distr instead, which
+is a separate code path that emits loc_* / sd_* columns. This script constructs the
 real MLForecast object the same way run_forecaster_validation.py does, feeds it
 a real slice of context data, calls predict_distr, and audits the output.
 
 Run on a GPU node:
-    python verify_predict_distr_phase0i_g.py
+    python verify_predict_distr_quantile_head.py
 """
 import logging
 import sys
@@ -102,7 +102,7 @@ def main():
             target_turbine_indices=None,
         )
 
-    forecaster = stage("Construct MLForecast (loads Phase 0i-G checkpoint)", build_forecaster)
+    forecaster = stage("Construct MLForecast (loads quantile-head checkpoint)", build_forecaster)
 
     stage("forecaster.reset()", lambda: forecaster.reset())
 
@@ -194,14 +194,14 @@ if __name__ == "__main__":
         summary = None
 
     print("\n" + "=" * 70)
-    print("VERIFICATION REPORT — predict_distr on Phase 0i-G checkpoint")
+    print("VERIFICATION REPORT — predict_distr on quantile-head checkpoint")
     print("=" * 70)
     for name, status, detail in STAGES:
         mark = "PASS" if status == "PASS" else "FAIL"
         print(f"  [{mark}] {name}" + (f"  — {detail}" if detail else ""))
     print("=" * 70)
     if ok and summary:
-        print(f"RESULT: predict_distr WORKS with Phase 0i-G.")
+        print(f"RESULT: predict_distr WORKS with the quantile-head checkpoint.")
         print(f"  output rows={summary['rows']}, loc_* cols={summary['loc_cols']}, "
               f"sd_* cols={summary['sd_cols']}, sd median={summary['sd_median']:.4f}")
         sys.exit(0)


### PR DESCRIPTION
## Summary
wind-forecasting's `DataModule` constructor parameter was renamed `data_path` -> `normalized_data_path` (plus an `assert "normalized" in ...` guard) and merged to `main` via PR #138. `tuning.py` and `initialize_case_studies.py` were already migrated; `ml_forecast.py` and `run_forecaster_validation.py` still used the old kwarg and now fail at `DataModule` construction against current wind-forecasting `main`.

This PR is a pure compatibility fix — the passed value (the model config's `data_path`, which points at a `*_normalized.parquet` file) is unchanged, so the new assertion is satisfied.

- `whoc/wind_forecast/ml_forecast.py:118` — `data_path=` -> `normalized_data_path=`
- `whoc/wind_forecast/run_forecaster_validation.py:1063` — same
- `whoc/wind_forecast/tests/verify_predict_distr_faithful.py` — same (in the test harness)
- Commits the previously-untracked `whoc/wind_forecast/tests/` verification scripts.

## Test plan
- [x] `from whoc.wind_forecast.ml_forecast import MLForecast` imports cleanly against wind-forecasting `main`
- [x] `DataModule.__init__` first param confirmed as `normalized_data_path`
- [x] `verify_predict_distr_faithful.py` re-run on H100 against updated `main` repos: all 8 stages PASS, `predict_distr` median 0.739 m/s, ratio to `predict_sample` oracle = 1.0021