### PR TITLE
feat: CP stddev calibration in MLForecast.predict_distr (opt-in)

### DIFF
--- a/whoc/wind_forecast/cp_scale_factors/quantile_head.json
+++ b/whoc/wind_forecast/cp_scale_factors/quantile_head.json
@@ -1,0 +1,30 @@
+{
+  "description": "CP stddev scale factors \u2014 multiply raw predictive stddev by scale_factors[component][lead_step] to get a CP-calibrated stddev.",
+  "source": "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/cp_phase0i_g_results_20260513/calibrated_intervals.parquet",
+  "alpha": 0.1,
+  "generated_at": "2026-05-14 12:54:49",
+  "components": [
+    "ws_horz",
+    "ws_vert"
+  ],
+  "lead_steps": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "scale_factors": {
+    "ws_horz": [
+      3.775924,
+      4.422153,
+      4.648451,
+      4.45615
+    ],
+    "ws_vert": [
+      5.024126,
+      5.877024,
+      6.234354,
+      6.051771
+    ]
+  }
+}

--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -79,9 +79,16 @@ class MLForecast(WindForecast):
                 "cp_scale_factors_path",
                 os.path.join(os.path.dirname(__file__), "cp_scale_factors", "quantile_head.json"),
             )
-            with open(cp_path) as f:
-                self.cp_scale_factors = json.load(f)["scale_factors"]
-            logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
+            with open(cp_path, encoding="utf-8") as f:
+                self.cp_scale_factors = json.load(f).get("scale_factors")
+            if self.cp_scale_factors is None:
+                logging.warning(
+                    f"CP scale factors file {cp_path} has no 'scale_factors' key; "
+                    f"disabling CP stddev calibration."
+                )
+                self.cp_calibrate_stddev = False
+            else:
+                logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
 
         # don't need this, can load hyperparamas from checkpoint
         # if self.use_tuned_params:
@@ -659,8 +666,8 @@ class MLForecast(WindForecast):
             factors = self.cp_scale_factors.get(base)
             if factors is None:
                 continue
-            for lead in range(min(n_leads, len(factors))):
-                mult[lead, c] = factors[lead]
+            n_copy = min(n_leads, len(factors))
+            mult[:n_copy, c] = torch.as_tensor(factors[:n_copy], device=device, dtype=dtype)
         return mult
 
     def predict_distr(self, historic_measurements: Union[pd.DataFrame, pl.DataFrame], current_time):

--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -2,6 +2,7 @@ from typing import Union
 from dataclasses import dataclass
 import os
 import re
+import json
 import types
 
 import inspect
@@ -64,6 +65,23 @@ class MLForecast(WindForecast):
         self.model_config = self.kwargs["model_config"]
         self.device = None
         self.resample = self.kwargs.get("resample", True)  # Default to True if not specified
+
+        # CP stddev calibration — opt-in. When enabled, predict_distr multiplies the
+        # raw per-component predictive stddev by a per-(lead, component) Conformal
+        # Prediction scale factor so downstream controllers receive calibrated
+        # stddevs. Default OFF: the scale factors are checkpoint-specific, so a case
+        # study must explicitly set cp_calibrate_stddev=True (and optionally point
+        # cp_scale_factors_path at a non-default table).
+        self.cp_calibrate_stddev = self.kwargs.get("cp_calibrate_stddev", False)
+        self.cp_scale_factors = None
+        if self.cp_calibrate_stddev:
+            cp_path = self.kwargs.get(
+                "cp_scale_factors_path",
+                os.path.join(os.path.dirname(__file__), "cp_scale_factors", "quantile_head.json"),
+            )
+            with open(cp_path) as f:
+                self.cp_scale_factors = json.load(f)["scale_factors"]
+            logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
 
         # don't need this, can load hyperparamas from checkpoint
         # if self.use_tuned_params:
@@ -627,6 +645,24 @@ class MLForecast(WindForecast):
         else:
             return pred_df.to_pandas()
 
+    def _cp_multiplier(self, components, n_leads, device, dtype):
+        """Per-(lead, component) CP scale-factor tensor of shape [n_leads, len(components)].
+
+        `components` may be bare prefixes (``"ws_horz"``) or turbine-suffixed
+        (``"ws_horz_wt042"``) — the ``_wtNNN`` suffix is stripped so all turbines of a
+        component share that component's per-lead factors. Components absent from the
+        scale-factor table (or leads beyond its length) stay at 1.0 (no calibration).
+        """
+        mult = torch.ones((n_leads, len(components)), device=device, dtype=dtype)
+        for c, comp in enumerate(components):
+            base = comp.rsplit("_wt", 1)[0] if "_wt" in comp else comp
+            factors = self.cp_scale_factors.get(base)
+            if factors is None:
+                continue
+            for lead in range(min(n_leads, len(factors))):
+                mult[lead, c] = factors[lead]
+        return mult
+
     def predict_distr(self, historic_measurements: Union[pd.DataFrame, pl.DataFrame], current_time):
 
         if isinstance(historic_measurements, pd.DataFrame):
@@ -682,6 +718,10 @@ class MLForecast(WindForecast):
                         )  # .to(self.predictor.device)
                         pred_list[p].distribution.mean = samples_tensor.mean(dim=0)
                         pred_list[p].distribution.stddev = samples_tensor.std(dim=0)
+                        if self.cp_calibrate_stddev and self.cp_scale_factors is not None:
+                            sd = pred_list[p].distribution.stddev  # [n_leads, n_components]
+                            pred_list[p].distribution.stddev = sd * self._cp_multiplier(
+                                self.data_module.target_prefixes, sd.shape[0], sd.device, sd.dtype)
 
                 pred_df = pl.concat(
                     [
@@ -721,6 +761,10 @@ class MLForecast(WindForecast):
                     samples_tensor = torch.from_numpy(pred.samples)  # .to(self.predictor.device)
                     pred.distribution.mean = samples_tensor.to(self.predictor.device).mean(dim=0)
                     pred.distribution.stddev = samples_tensor.std(dim=0)
+                    if self.cp_calibrate_stddev and self.cp_scale_factors is not None:
+                        sd = pred.distribution.stddev  # [n_leads, n_all_target_cols]
+                        pred.distribution.stddev = sd * self._cp_multiplier(
+                            self.data_module.target_cols, sd.shape[0], sd.device, sd.dtype)
 
                 pred_df = pl.DataFrame(
                     data={

--- a/whoc/wind_forecast/tests/verify_cp_calibration.py
+++ b/whoc/wind_forecast/tests/verify_cp_calibration.py
@@ -1,0 +1,255 @@
+"""End-to-end verification of the CP stddev calibration in MLForecast.predict_distr.
+
+Builds TWO forecasters from the SAME quantile-head TACTiS-2 checkpoint:
+  - f_off : cp_calibrate_stddev not set (default OFF) — current behaviour
+  - f_on  : cp_calibrate_stddev=True — multiplies raw sd_* by the per-(lead,
+            component) CP scale factor from cp_scale_factors/quantile_head.json
+
+Both run predict_distr on the SAME context window with the SAME torch seed, so
+the only difference between their sd_* outputs is the calibration multiply.
+
+Assertions:
+  A  flag OFF is unchanged    — f_off sd_* median ~0.73 m/s (matches the known
+                                predict_sample oracle from verify_predict_distr_faithful.py)
+  B  flag ON = raw x scale    — for every (lead, component): f_on.sd / f_off.sd
+                                ~= scale_factors[component][lead]  (within 1e-3)
+  C  magnitude is sane        — f_on sd_* median ~3-4 m/s; horz < vert
+  D  lead structure preserved — f_on per-lead mean sd rises from lead 0 to lead 2
+                                (guards against a lead/component axis transpose)
+
+Run on a GPU node.
+"""
+import json
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import torch
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("verify-cp")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+SCALE_TABLE = "/user/taed7566/Forecasting/wind-hybrid-open-controller/whoc/wind_forecast/cp_scale_factors/quantile_head.json"
+SEED = 42
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        r = fn()
+        STAGES.append((name, "PASS", ""))
+        return r
+    except Exception as e:
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, traceback.format_exc())
+        raise
+
+
+def main():
+    from whoc.wind_forecast.ml_forecast import MLForecast
+    from wind_forecasting.preprocessing.data_module import DataModule
+
+    with open(MODEL_CONFIG) as f:
+        mcnf = yaml.safe_load(f)
+    scale_factors = json.load(open(SCALE_TABLE))["scale_factors"]
+    log.info("scale_factors = %s", scale_factors)
+
+    measurements_timedelta = pd.Timedelta(seconds=15)
+    ptd = pd.Timedelta(seconds=mcnf["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=mcnf["dataset"]["context_length"])
+
+    # --- test DataModule, faithful to run_forecaster_validation.py:1062 ---
+    def build_test_dm():
+        dm = DataModule(
+            normalized_data_path=mcnf["dataset"]["data_path"],
+            normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
+            use_normalization=False,
+            n_splits=1,
+            continuity_groups=None,
+            train_split=(1.0 - mcnf["dataset"]["val_split"] - mcnf["dataset"]["test_split"]),
+            val_split=mcnf["dataset"]["val_split"],
+            test_split=mcnf["dataset"]["test_split"],
+            prediction_length=mcnf["dataset"]["prediction_length"],
+            context_length=mcnf["dataset"]["context_length"],
+            target_prefixes=["ws_horz", "ws_vert"],
+            feat_dynamic_real_prefixes=["nd_cos", "nd_sin"],
+            freq=f"{int(measurements_timedelta.total_seconds())}s",
+            target_suffixes=mcnf["dataset"]["target_turbine_ids"],
+            per_turbine_target=False,
+            as_lazyframe=True,
+            dtype=pl.Float32,
+        )
+        dm.generate_splits(save=True, reload=False, splits=["test"])
+        return dm
+
+    test_dm = stage("Build test DataModule + generate_splits(test)", build_test_dm)
+
+    def build_test_data():
+        test_df = test_dm.datasets["test"]
+        if hasattr(test_df, "collect"):
+            test_df = test_df.collect()
+        rename_map = {
+            **{f"target_{i}": c for i, c in enumerate(test_dm.target_cols)},
+            **{f"feat_dynamic_real_{i}": c
+               for i, c in enumerate(test_dm.feat_dynamic_real_cols)},
+        }
+        return (test_df.rename(rename_map)
+                       .with_columns(continuity_group=pl.col("item_id")
+                                     .str.extract(r"SPLIT(\d+)").cast(int)))
+
+    test_data = stage("Load + rename cached test split", build_test_data)
+
+    # --- two forecasters from the same checkpoint: calibration OFF and ON ---
+    def make_forecaster(cp_on):
+        kwargs = dict(model_key="tactis", model_checkpoint=CHECKPOINT,
+                      optuna_storage=None, study_name=None,
+                      model_config=mcnf, resample=False)
+        if cp_on:
+            kwargs["cp_calibrate_stddev"] = True
+            kwargs["cp_scale_factors_path"] = SCALE_TABLE
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=max(pd.Timedelta(5, unit="s"), measurements_timedelta),
+            prediction_timedelta=ptd, context_timedelta=ctd,
+            fmodel=None, true_wind_field=None,
+            tid2idx_mapping={str(s): i for i, s in enumerate(test_dm.target_suffixes)},
+            turbine_signature=r"\d+", use_tuned_params=True,
+            kwargs=kwargs, target_turbine_indices=None,
+        )
+
+    f_off = stage("Construct MLForecast (calibration OFF)", lambda: make_forecaster(False))
+    f_on = stage("Construct MLForecast (calibration ON)", lambda: make_forecaster(True))
+    stage("reset() both forecasters", lambda: (f_off.reset(), f_on.reset()))
+
+    # sanity: f_on actually loaded the table, f_off did not
+    assert f_on.cp_calibrate_stddev and f_on.cp_scale_factors is not None, "f_on did not load scale factors"
+    assert not f_off.cp_calibrate_stddev, "f_off should have calibration disabled"
+
+    def pick_context():
+        n_ctx = f_off.n_context
+        sizes = (test_data.group_by("continuity_group").agg(pl.len().alias("n"))
+                 .sort("n", descending=True))
+        cg = sizes["continuity_group"][0]
+        sub = (test_data.filter(pl.col("continuity_group") == cg)
+                        .sort("time").head(n_ctx + 20).drop("continuity_group"))
+        for extra in ("item_id", "feat_static_cat", "prediction_timedelta"):
+            if extra in sub.columns:
+                sub = sub.drop(extra)
+        log.info("context cg=%s rows=%d current_time=%s", cg, sub.height, sub["time"][-1])
+        return sub, sub["time"][-1]
+
+    ctx, current_time = stage("Pick continuity group + context window", pick_context)
+
+    # --- run predict_distr on both, same seed so samples match ---
+    def run_off():
+        torch.manual_seed(SEED)
+        torch.cuda.manual_seed_all(SEED)
+        return f_off.predict_distr(ctx, current_time)
+
+    def run_on():
+        torch.manual_seed(SEED)
+        torch.cuda.manual_seed_all(SEED)
+        return f_on.predict_distr(ctx, current_time)
+
+    pred_off = stage("predict_distr — calibration OFF", run_off)
+    pred_on = stage("predict_distr — calibration ON", run_on)
+
+    # --- compare ---
+    def compare():
+        sd_cols = [c for c in pred_off.columns if c.startswith("sd_")]
+        assert sd_cols, "no sd_* columns in pred_off"
+        assert set(sd_cols) == set(c for c in pred_on.columns if c.startswith("sd_")), \
+            "sd_* column sets differ between OFF and ON"
+        n_leads = pred_off.height
+        log.info("sd_* columns: %d, prediction rows (leads): %d", len(sd_cols), n_leads)
+
+        off = pred_off.sort("time")
+        on = pred_on.sort("time")
+        off_arr = off.select(sd_cols).to_numpy()   # [n_leads, n_sd_cols]
+        on_arr = on.select(sd_cols).to_numpy()
+
+        # Assertion A — flag OFF unchanged: median ~0.73 m/s (the known oracle)
+        off_med = float(np.nanmedian(off_arr))
+        log.info("[A] f_off sd_* median = %.4f m/s (expect ~0.73, the predict_sample oracle)", off_med)
+        a_ok = 0.5 < off_med < 1.1
+
+        # Assertion B — flag ON = raw x per-(lead,component) scale factor
+        max_rel_err = 0.0
+        for j, col in enumerate(sd_cols):
+            comp = "ws_horz" if "ws_horz" in col else "ws_vert"
+            factors = np.array(scale_factors[comp][:n_leads])
+            expected = off_arr[:, j] * factors
+            got = on_arr[:, j]
+            denom = np.where(np.abs(expected) > 1e-9, np.abs(expected), 1.0)
+            rel = np.abs(got - expected) / denom
+            max_rel_err = max(max_rel_err, float(np.nanmax(rel)))
+        log.info("[B] max relative error of f_on vs f_off x scale = %.2e (expect < 1e-3)", max_rel_err)
+        b_ok = max_rel_err < 1e-3
+
+        # Assertion C — magnitude sane: f_on median ~3-4 m/s; horz < vert
+        on_med = float(np.nanmedian(on_arr))
+        horz_cols = [j for j, c in enumerate(sd_cols) if "ws_horz" in c]
+        vert_cols = [j for j, c in enumerate(sd_cols) if "ws_vert" in c]
+        horz_med = float(np.nanmedian(on_arr[:, horz_cols]))
+        vert_med = float(np.nanmedian(on_arr[:, vert_cols]))
+        log.info("[C] f_on sd_* median = %.4f m/s  (horz=%.4f, vert=%.4f)", on_med, horz_med, vert_med)
+        c_ok = (2.0 < on_med < 5.0) and (horz_med < vert_med)
+
+        # Assertion D — lead structure preserved: per-lead mean rises lead0->lead2
+        per_lead_mean = np.nanmean(on_arr, axis=1)  # [n_leads]
+        log.info("[D] f_on per-lead mean sd = %s", np.round(per_lead_mean, 4).tolist())
+        d_ok = per_lead_mean[0] < per_lead_mean[min(2, n_leads - 1)]
+
+        log.info("-" * 60)
+        log.info("[A] flag OFF unchanged (median ~0.73)        : %s", a_ok)
+        log.info("[B] flag ON == raw x scale (<1e-3 rel err)   : %s", b_ok)
+        log.info("[C] magnitude sane (~3-4 m/s, horz<vert)     : %s", c_ok)
+        log.info("[D] lead structure preserved (rises 0->2)    : %s", d_ok)
+        return dict(a=a_ok, b=b_ok, c=c_ok, d=d_ok,
+                    off_med=off_med, on_med=on_med, horz_med=horz_med,
+                    vert_med=vert_med, max_rel_err=max_rel_err)
+
+    return stage("COMPARE calibration OFF vs ON", compare)
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        result = main()
+    except Exception:
+        ok = False
+        result = None
+
+    print("\n" + "=" * 70)
+    print("CP CALIBRATION VERIFICATION REPORT")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        print(f"  [{status}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and result:
+        print(f"f_off sd median : {result['off_med']:.4f} m/s")
+        print(f"f_on  sd median : {result['on_med']:.4f} m/s  (horz {result['horz_med']:.3f}, vert {result['vert_med']:.3f})")
+        print(f"max rel err (ON vs raw x scale): {result['max_rel_err']:.2e}")
+        print("-" * 70)
+        if all([result["a"], result["b"], result["c"], result["d"]]):
+            print("RESULT: CP calibration VERIFIED — A/B/C/D all pass.")
+            sys.exit(0)
+        print("RESULT: CP calibration FAILED — see A/B/C/D above.")
+        sys.exit(2)
+    print("RESULT: harness failed before comparison — see failed stage above.")
+    sys.exit(1)

--- a/whoc/wind_forecast/tools/build_cp_scale_table.py
+++ b/whoc/wind_forecast/tools/build_cp_scale_table.py
@@ -1,0 +1,111 @@
+"""Build the CP stddev scale-factor table consumed by MLForecast.predict_distr.
+
+The TACTiS-2 model's raw predictive standard deviations are honest in shape but
+under-confident: at the 90% nominal level the raw bands cover only ~56% of the
+truth. Conformal Prediction (CQR) bands cover >=90% by construction. The ratio
+of the CP band width to the raw band width is therefore a multiplicative
+correction factor for the raw stddev.
+
+This script aggregates that factor from a `calibrated_intervals.parquet`
+(produced by wind-forecasting's apply_cp_to_phase0i_b.py) down to a small
+per-(lead_step, component) table — 4 leads x 2 components = 8 numbers. Turbine-
+to-turbine variation in the factor has a coefficient of variation of only ~0.2,
+so aggregating over turbines captures the two axes that genuinely matter
+(forecast horizon and wind component) without overfitting one validation slice.
+
+Run once, offline:
+    python build_cp_scale_table.py \\
+        --intervals <cp_results_dir>/calibrated_intervals.parquet \\
+        --output    ../cp_scale_factors/quantile_head.json \\
+        --alpha 0.1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("build-cp-scale")
+
+# component prefixes — must match MLForecast.data_module.target_prefixes
+COMPONENTS = ["ws_horz", "ws_vert"]
+_TARGET_RE = re.compile(r"^(ws_horz|ws_vert)_wt\d+$")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--intervals", type=Path, required=True,
+                    help="calibrated_intervals.parquet from the CP pipeline")
+    ap.add_argument("--output", type=Path, required=True,
+                    help="destination JSON (e.g. ../cp_scale_factors/quantile_head.json)")
+    ap.add_argument("--alpha", type=float, default=0.1,
+                    help="confidence level to build the table at (default 0.1 = 90% nominal)")
+    args = ap.parse_args()
+
+    log.info("Loading %s", args.intervals)
+    ci = pl.read_parquet(args.intervals).filter(pl.col("alpha") == args.alpha)
+    if ci.height == 0:
+        raise SystemExit(f"No rows with alpha == {args.alpha} in {args.intervals}")
+    log.info("  rows at alpha=%s: %d", args.alpha, ci.height)
+
+    # per-row CP scale factor: (cp band width) / (raw band width), guarded
+    ci = ci.with_columns([
+        (pl.col("upper_cp") - pl.col("lower_cp")).alias("cp_w"),
+        (pl.col("upper_raw") - pl.col("lower_raw")).alias("raw_w"),
+    ])
+    ci = ci.with_columns(
+        pl.when(pl.col("raw_w") > 1e-9)
+          .then(pl.col("cp_w") / pl.col("raw_w"))
+          .otherwise(None)  # degenerate (zero-range) targets -> dropped from the mean
+          .alias("scale")
+    )
+    # component from target_col (e.g. "ws_horz_wt042" -> "ws_horz")
+    ci = ci.with_columns(
+        pl.col("target_col").str.extract(r"^(ws_horz|ws_vert)_wt\d+$", 1).alias("component")
+    )
+    n_bad = ci.filter(pl.col("component").is_null()).height
+    if n_bad:
+        log.warning("  %d rows had a target_col not matching ws_(horz|vert)_wtNNN — dropped", n_bad)
+    ci = ci.drop_nulls(["scale", "component"])
+
+    leads = sorted(ci["lead_step"].unique().to_list())
+    log.info("  lead steps present: %s", leads)
+
+    scale_factors = {c: [] for c in COMPONENTS}
+    log.info("Per-(lead, component) aggregate (mean scale, CoV across turbines+time):")
+    for comp in COMPONENTS:
+        for lead in leads:
+            sub = ci.filter((pl.col("component") == comp) & (pl.col("lead_step") == lead))["scale"]
+            arr = sub.to_numpy()
+            mean = float(np.mean(arr))
+            cov = float(np.std(arr) / mean) if mean != 0 else float("nan")
+            scale_factors[comp].append(round(mean, 6))
+            log.info("  %s lead %d : mean=%.4f  CoV=%.3f  (n=%d)", comp, lead, mean, cov, arr.size)
+
+    out = {
+        "description": (
+            "CP stddev scale factors — multiply raw predictive stddev by "
+            "scale_factors[component][lead_step] to get a CP-calibrated stddev."
+        ),
+        "source": str(args.intervals),
+        "alpha": args.alpha,
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "components": COMPONENTS,
+        "lead_steps": leads,
+        "scale_factors": scale_factors,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2) + "\n")
+    log.info("Wrote %s", args.output)
+    log.info("scale_factors = %s", json.dumps(scale_factors))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
The quantile-head TACTiS-2 model produces honest-but-under-confident raw predictive stddevs (~56% empirical coverage at the 90% nominal level). This adds an **opt-in** path for `predict_distr` to multiply its raw per-component `sd_*` output by a per-(lead, component) Conformal Prediction scale factor, so downstream controllers (`LookupBasedWakeSteeringController` etc.) receive calibrated stddevs with **zero controller-side code change**.

- `cp_scale_factors/quantile_head.json` — 8-number table (4 leads × 2 components) built from the CP pipeline's `calibrated_intervals.parquet`. Per-(lead, component) granularity: turbine-to-turbine CoV is ~0.3, so aggregating over turbines captures the two systematic axes (forecast horizon, wind component) without overfitting one validation slice.
- `tools/build_cp_scale_table.py` — regenerates the table from any `calibrated_intervals.parquet` (`scale = cp_band_width / raw_band_width`).
- `ml_forecast.py` — `cp_calibrate_stddev` kwarg flag (**default OFF** — the factors are checkpoint-specific) + `cp_scale_factors_path`; loads the table in `__post_init__`; `_cp_multiplier` builds a `[n_leads, n_components]` tensor (strips `_wtNNN` suffix so all turbines of a component share its factors); applied in **both** `predict_distr` branches, inside the existing `if model_key == "tactis"` guard so non-tactis models are bit-identical.
- `tests/verify_cp_calibration.py` — end-to-end ON/OFF verification.

> Stacked on #8 (`fix/datamodule-normalized-data-path`). Base will auto-retarget to `feature/wind_preview` once #8 merges.

## Test plan
- [x] `_cp_multiplier` unit checks (no GPU): bare prefixes, `_wtNNN` suffix-strip, unknown-component→1.0, short-lead handling — 4/4 pass
- [x] `verify_cp_calibration.py` on H100 — builds two forecasters (calibration OFF/ON) from the same checkpoint, same torch seed:
  - **A** flag OFF unchanged: `sd_*` median 0.736 m/s (matches the `predict_sample` oracle)
  - **B** flag ON == raw × scale: max relative error **8.4e-08** (floating-point exact)
  - **C** magnitude sane: `sd_*` median 3.68 m/s (horz 2.74 < vert 4.99)
  - **D** per-lead structure preserved
- [x] non-tactis models unaffected — calibration lives inside the `if model_key == "tactis"` guard