### PR TITLE
CP stddev calibration in MLForecast.predict_distr + Phase 7 controller validation

### DIFF
--- a/examples/hercules_input_001.yaml
+++ b/examples/hercules_input_001.yaml
@@ -109,7 +109,17 @@ controller:
 wind_forecast:
   context_timedelta: 600 # seconds
   prediction_timedelta: 60 # seconds
-  model_config_path: 
+  model_config_path:
+  # cp_calibrate_stddev MUST sit at this top level (not nested under MLForecast).
+  # initialize_case_studies.py iterates case.items() in alphabetical key order
+  # AND the routing predicate's nested check only fires if wind_forecast_class
+  # has already been assigned this loop iteration. cp_calibrate_stddev sorts
+  # before wind_forecast_class, so at the moment it is processed the
+  # controller's wind_forecast_class is still the wcnf default `False`,
+  # short-circuiting the nested check. Registering at this top level makes the
+  # FIRST clause of the routing predicate match immediately. Default `false`
+  # keeps calibration opt-in per case.
+  cp_calibrate_stddev: false
   SVRForecast:
     model_key: svr
     kernel: rbf
@@ -125,9 +135,3 @@ wind_forecast:
   MLForecast:
     model_key: informer
     model_checkpoint: best
-    # Registering cp_calibrate_stddev here is REQUIRED for the case-study harness to
-    # route a per-case `cp_calibrate_stddev` value into MLForecast.kwargs. Routing in
-    # initialize_case_studies.py (~L1734) only forwards a param into ["wind_forecast"]
-    # if the key already exists in this wcnf block; otherwise it is silently dropped.
-    # Default false matches MLForecast's own default — calibration stays opt-in per case.
-    cp_calibrate_stddev: false

--- a/examples/hercules_input_001.yaml
+++ b/examples/hercules_input_001.yaml
@@ -125,3 +125,9 @@ wind_forecast:
   MLForecast:
     model_key: informer
     model_checkpoint: best
+    # Registering cp_calibrate_stddev here is REQUIRED for the case-study harness to
+    # route a per-case `cp_calibrate_stddev` value into MLForecast.kwargs. Routing in
+    # initialize_case_studies.py (~L1734) only forwards a param into ["wind_forecast"]
+    # if the key already exists in this wcnf block; otherwise it is silently dropped.
+    # Default false matches MLForecast's own default — calibration stays opt-in per case.
+    cp_calibrate_stddev: false

--- a/whoc/case_studies/bash_script_storm_gpu.sh
+++ b/whoc/case_studies/bash_script_storm_gpu.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-#SBATCH --partition=cfdg.p                 # Storm GPU partition (7-day cap)
-#SBATCH --nodes=2
+#SBATCH --partition=cfdg.p                 # Storm GPU partition (7-day cap). cfdg.p's only
+#SBATCH --nodes=1                          #   H100 node is cfdg002 (H100:4) — single node, 4 GPUs.
 #SBATCH --ntasks-per-node=4                # one MPI task per GPU (gpu_cycler maps 1:1)
-#SBATCH --gres=gpu:H100:4                  # 4 H100 per node
+#SBATCH --gres=gpu:H100:4                  # all 4 H100 on the node
 #SBATCH --cpus-per-task=8
 #SBATCH --mem-per-cpu=8016
-#SBATCH --exclude=cfdg001
+#SBATCH --exclude=cfdg001                  # cfdg001 is A100; we want H100 (cfdg002)
 #SBATCH --time=2-00:00:00                  # generous: first run also generates the AWAKEN LUTs at init
 #SBATCH --job-name=cs29_tactis_quantile_cp
 #SBATCH --output=/dss/work/taed7566/Forecasting_Outputs/wind-hybrid-open-controller/logs/slurm_logs/cs29_%j.out

--- a/whoc/case_studies/bash_script_storm_gpu.sh
+++ b/whoc/case_studies/bash_script_storm_gpu.sh
@@ -45,11 +45,14 @@ export PYTHONPATH=${BASE_DIR}/floris:${WHOC_DIR}:${WF_DIR}:${BASE_DIR}/pytorch-t
 export NUMEXPR_MAX_THREADS=8
 export POLARS_MAX_THREADS=1                # avoid Polars/MPI thread contention
 
-# --- Modules (Storm) — same set as the verified train_phase0i_g.sh production run ---
+# --- Modules (Storm) ---
+# Do NOT load the mpi4py module: it is built for python3.11 and shadows (via PYTHONPATH)
+# the python3.12 conda env's own mpi4py, causing `from mpi4py import MPI` to ImportError.
+# wf_env_storm ships mpi4py 4.1.1 + MPICH 4.3.2 — use the conda env's MPI (same approach
+# as bash_script_storm_cpu.sh).
 module purge
 module load slurm/hpc-2023/23.02.7
 module load hpc-env/13.1
-module load mpi4py/3.1.4-gompi-2023a
 module load Mamba/24.3.0-0
 module load CUDA/12.4.0
 module load git

--- a/whoc/case_studies/bash_script_storm_gpu.sh
+++ b/whoc/case_studies/bash_script_storm_gpu.sh
@@ -2,11 +2,11 @@
 
 #SBATCH --partition=cfdg.p                 # Storm GPU partition (7-day cap). cfdg.p's only
 #SBATCH --nodes=1                          #   H100 node is cfdg002 (H100:4) — single node, 4 GPUs.
-#SBATCH --ntasks-per-node=4                # one MPI task per GPU (gpu_cycler maps 1:1)
+#SBATCH --ntasks-per-node=1                # cf (ProcessPoolExecutor) = ONE main process; it forks
+#SBATCH --cpus-per-task=32                 #   the worker pool itself. NOT MPI multi-rank.
 #SBATCH --gres=gpu:H100:4                  # all 4 H100 on the node
-#SBATCH --cpus-per-task=8
-#SBATCH --mem-per-cpu=8016
-#SBATCH --exclude=cfdg001                  # cfdg001 is A100; we want H100 (cfdg002)
+#SBATCH --mem-per-cpu=24000                # 32 x 24000 MB = 768 GB for the node (main + 4 workers
+#SBATCH --exclude=cfdg001                  #   each load a DataModule ~60 GB; fits with headroom)
 #SBATCH --time=2-00:00:00                  # generous: first run also generates the AWAKEN LUTs at init
 #SBATCH --job-name=cs29_tactis_quantile_cp
 #SBATCH --output=/dss/work/taed7566/Forecasting_Outputs/wind-hybrid-open-controller/logs/slurm_logs/cs29_%j.out
@@ -22,10 +22,15 @@
 #   arm 2: LookupBasedWakeSteering, uncertain=True,  cp_calibrate_stddev=True  (CP-calibrated)
 #   arm 3: LookupBasedWakeSteering, uncertain=False  (deterministic LUT baseline)
 #   arm 4: GreedyController                          (no-wake-steering floor)
-# The harness auto-generates the 2 AWAKEN LUTs at initialize_simulations() time
-# (root rank, deduped) since examples/inputs/lut_gch_KP_v4_* do not exist yet.
+#
+# Uses --multiprocessor cf (ProcessPoolExecutor) NOT mpi: a single main process
+# runs initialize_simulations() once (loads the DataModule + auto-generates the 2
+# AWAKEN LUTs), then forks a 4-worker pool, one worker per H100 via the gpu_cycler.
+# This sidesteps the srun<->MPICH PMI mismatch that made each MPI rank an
+# independent rank-0 (4x the DataModule load -> OOM at init).
 #
 # Submit:  sbatch bash_script_storm_gpu.sh
+#   (race the all_gpu.p partition too: sbatch --partition=all_gpu.p --time=24:00:00 bash_script_storm_gpu.sh)
 # =============================================================================
 
 # --- Base Directories ---
@@ -40,16 +45,13 @@ export CASE_STUDY_OUTPUT_DIR="${OUTPUT_DIR}/floris_case_studies"
 mkdir -p ${LOG_DIR}/slurm_logs ${CASE_STUDY_OUTPUT_DIR}
 cd ${WORK_DIR} || exit 1
 
-# Local FLORIS / WHOC / wind-forecasting on PYTHONPATH (development versions)
 export PYTHONPATH=${BASE_DIR}/floris:${WHOC_DIR}:${WF_DIR}:${BASE_DIR}/pytorch-transformer-ts:${PYTHONPATH}
 export NUMEXPR_MAX_THREADS=8
-export POLARS_MAX_THREADS=1                # avoid Polars/MPI thread contention
+export POLARS_MAX_THREADS=1                # avoid Polars thread contention across the worker pool
 
 # --- Modules (Storm) ---
-# Do NOT load the mpi4py module: it is built for python3.11 and shadows (via PYTHONPATH)
-# the python3.12 conda env's own mpi4py, causing `from mpi4py import MPI` to ImportError.
-# wf_env_storm ships mpi4py 4.1.1 + MPICH 4.3.2 — use the conda env's MPI (same approach
-# as bash_script_storm_cpu.sh).
+# No mpi4py module: cf does not use MPI, and the module's python3.11 mpi4py would
+# anyway shadow wf_env_storm's python3.12 build (ABI mismatch).
 module purge
 module load slurm/hpc-2023/23.02.7
 module load hpc-env/13.1
@@ -59,39 +61,42 @@ module load git
 eval "$(conda shell.bash hook)"
 conda activate wf_env_storm
 
-# --- GPU visibility for run_case_studies.py's gpu_cycler ---
-# SLURM_JOB_GPUS is the comma-separated GPU id list; derive the per-node count and
-# expose a 0-based list so the gpu_cycler round-robins assigned_gpu across MPI tasks.
+# --- GPU visibility + worker count for run_case_studies.py ---
+# CUDA_VISIBLE_DEVICES feeds the gpu_cycler; SLURM_NTASKS_PER_NODE sets the
+# ProcessPoolExecutor's max_workers (run_case_studies.py:199). With cf and
+# --ntasks-per-node=1, SLURM sets that env to 1 — override it to the GPU count
+# so the pool actually has one worker per GPU.
 devices=$SLURM_JOB_GPUS
 n_devices=$(( ${#devices} / 2 + 1 ))
 export CUDA_VISIBLE_DEVICES=$(seq -s, 0 $(( n_devices - 1 )))
+export SLURM_NTASKS_PER_NODE=${n_devices}
 
 echo "================================================================"
-echo "CASE STUDY 29 — baseline_controllers_tactis_quantile_head_cp_awaken"
+echo "CASE STUDY 29 — baseline_controllers_tactis_quantile_head_cp_awaken (cf, ${n_devices} workers)"
 echo "================================================================"
 echo "JOB ID:        ${SLURM_JOB_ID}"
 echo "PARTITION:     ${SLURM_JOB_PARTITION}"
-echo "NODES:         ${SLURM_JOB_NODELIST}"
-echo "TASKS/NODE:    ${SLURM_NTASKS_PER_NODE}   TOTAL TASKS: ${SLURM_NTASKS}"
-echo "SLURM_JOB_GPUS=${SLURM_JOB_GPUS}  ->  CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
+echo "NODE:          ${SLURM_JOB_NODELIST}"
+echo "SLURM_JOB_GPUS=${SLURM_JOB_GPUS}  ->  CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}  workers=${SLURM_NTASKS_PER_NODE}"
 echo "GPU TYPE:      $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | uniq)"
 echo "branch: $(cd ${WHOC_DIR} && git rev-parse --abbrev-ref HEAD) @ $(cd ${WHOC_DIR} && git rev-parse --short HEAD)"
 echo "================================================================"
 
 # --- Config files ---
-WCNF="${WHOC_DIR}/examples/hercules_input_001.yaml"                                          # wind controller config (has cp_calibrate_stddev registered under MLForecast)
-DCNF="${WF_DIR}/config/preprocessing/preprocessing_inputs_awaken_STORM.yaml"                  # data preprocessing config
-MCNF="${WF_DIR}/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"  # quantile-head model config
+WCNF="${WHOC_DIR}/examples/hercules_input_001.yaml"                                          # has cp_calibrate_stddev registered under MLForecast
+DCNF="${WF_DIR}/config/preprocessing/preprocessing_inputs_awaken_STORM.yaml"
+MCNF="${WF_DIR}/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
 
 for f in "$WCNF" "$DCNF" "$MCNF"; do
     [ -f "$f" ] || { echo "ERROR: config not found: $f" >&2; exit 1; }
 done
 
 date +"%Y-%m-%d %H:%M:%S"
-echo "=== STARTING run_case_studies.py 29 ==="
+echo "=== STARTING run_case_studies.py 29 (--multiprocessor cf) ==="
 
-srun python run_case_studies.py 29 \
-    --multiprocessor mpi \
+# cf = single main process forking a worker pool — run python directly, no srun multi-rank.
+python run_case_studies.py 29 \
+    --multiprocessor cf \
     -rs \
     --ram_limit 32 \
     --wf_source scada \

--- a/whoc/case_studies/bash_script_storm_gpu.sh
+++ b/whoc/case_studies/bash_script_storm_gpu.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+#SBATCH --partition=cfdg.p                 # Storm GPU partition (7-day cap)
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=4                # one MPI task per GPU (gpu_cycler maps 1:1)
+#SBATCH --gres=gpu:H100:4                  # 4 H100 per node
+#SBATCH --cpus-per-task=8
+#SBATCH --mem-per-cpu=8016
+#SBATCH --exclude=cfdg001
+#SBATCH --time=2-00:00:00                  # generous: first run also generates the AWAKEN LUTs at init
+#SBATCH --job-name=cs29_tactis_quantile_cp
+#SBATCH --output=/dss/work/taed7566/Forecasting_Outputs/wind-hybrid-open-controller/logs/slurm_logs/cs29_%j.out
+#SBATCH --error=/dss/work/taed7566/Forecasting_Outputs/wind-hybrid-open-controller/logs/slurm_logs/cs29_%j.err
+#SBATCH --hint=nomultithread
+#SBATCH --distribution=block:block
+
+# =============================================================================
+# Case study 29 — baseline_controllers_tactis_quantile_head_cp_awaken
+# Controller validation of the quantile-head TACTiS-2 model with CP stddev
+# calibration. 4 arms x 30 wind seeds:
+#   arm 1: LookupBasedWakeSteering, uncertain=True,  cp_calibrate_stddev=False (raw)
+#   arm 2: LookupBasedWakeSteering, uncertain=True,  cp_calibrate_stddev=True  (CP-calibrated)
+#   arm 3: LookupBasedWakeSteering, uncertain=False  (deterministic LUT baseline)
+#   arm 4: GreedyController                          (no-wake-steering floor)
+# The harness auto-generates the 2 AWAKEN LUTs at initialize_simulations() time
+# (root rank, deduped) since examples/inputs/lut_gch_KP_v4_* do not exist yet.
+#
+# Submit:  sbatch bash_script_storm_gpu.sh
+# =============================================================================
+
+# --- Base Directories ---
+BASE_DIR="/user/taed7566/Forecasting"
+OUTPUT_DIR="/dss/work/taed7566/Forecasting_Outputs/wind-hybrid-open-controller"
+WHOC_DIR="${BASE_DIR}/wind-hybrid-open-controller"
+WF_DIR="${BASE_DIR}/wind-forecasting"
+export WORK_DIR="${WHOC_DIR}/whoc/case_studies"
+export LOG_DIR="${OUTPUT_DIR}/logs"
+export CASE_STUDY_OUTPUT_DIR="${OUTPUT_DIR}/floris_case_studies"
+
+mkdir -p ${LOG_DIR}/slurm_logs ${CASE_STUDY_OUTPUT_DIR}
+cd ${WORK_DIR} || exit 1
+
+# Local FLORIS / WHOC / wind-forecasting on PYTHONPATH (development versions)
+export PYTHONPATH=${BASE_DIR}/floris:${WHOC_DIR}:${WF_DIR}:${BASE_DIR}/pytorch-transformer-ts:${PYTHONPATH}
+export NUMEXPR_MAX_THREADS=8
+export POLARS_MAX_THREADS=1                # avoid Polars/MPI thread contention
+
+# --- Modules (Storm) — same set as the verified train_phase0i_g.sh production run ---
+module purge
+module load slurm/hpc-2023/23.02.7
+module load hpc-env/13.1
+module load mpi4py/3.1.4-gompi-2023a
+module load Mamba/24.3.0-0
+module load CUDA/12.4.0
+module load git
+eval "$(conda shell.bash hook)"
+conda activate wf_env_storm
+
+# --- GPU visibility for run_case_studies.py's gpu_cycler ---
+# SLURM_JOB_GPUS is the comma-separated GPU id list; derive the per-node count and
+# expose a 0-based list so the gpu_cycler round-robins assigned_gpu across MPI tasks.
+devices=$SLURM_JOB_GPUS
+n_devices=$(( ${#devices} / 2 + 1 ))
+export CUDA_VISIBLE_DEVICES=$(seq -s, 0 $(( n_devices - 1 )))
+
+echo "================================================================"
+echo "CASE STUDY 29 — baseline_controllers_tactis_quantile_head_cp_awaken"
+echo "================================================================"
+echo "JOB ID:        ${SLURM_JOB_ID}"
+echo "PARTITION:     ${SLURM_JOB_PARTITION}"
+echo "NODES:         ${SLURM_JOB_NODELIST}"
+echo "TASKS/NODE:    ${SLURM_NTASKS_PER_NODE}   TOTAL TASKS: ${SLURM_NTASKS}"
+echo "SLURM_JOB_GPUS=${SLURM_JOB_GPUS}  ->  CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
+echo "GPU TYPE:      $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | uniq)"
+echo "branch: $(cd ${WHOC_DIR} && git rev-parse --abbrev-ref HEAD) @ $(cd ${WHOC_DIR} && git rev-parse --short HEAD)"
+echo "================================================================"
+
+# --- Config files ---
+WCNF="${WHOC_DIR}/examples/hercules_input_001.yaml"                                          # wind controller config (has cp_calibrate_stddev registered under MLForecast)
+DCNF="${WF_DIR}/config/preprocessing/preprocessing_inputs_awaken_STORM.yaml"                  # data preprocessing config
+MCNF="${WF_DIR}/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"  # quantile-head model config
+
+for f in "$WCNF" "$DCNF" "$MCNF"; do
+    [ -f "$f" ] || { echo "ERROR: config not found: $f" >&2; exit 1; }
+done
+
+date +"%Y-%m-%d %H:%M:%S"
+echo "=== STARTING run_case_studies.py 29 ==="
+
+srun python run_case_studies.py 29 \
+    --multiprocessor mpi \
+    -rs \
+    --ram_limit 32 \
+    --wf_source scada \
+    -st auto \
+    -ns 30 \
+    -sd ${CASE_STUDY_OUTPUT_DIR} \
+    -wcnf ${WCNF} \
+    -dcnf ${DCNF} \
+    -mcnf ${MCNF}
+
+EXIT_CODE=$?
+echo "=== CASE STUDY FINISHED (exit ${EXIT_CODE}) ==="
+date +"%Y-%m-%d %H:%M:%S"
+echo "Results: ${CASE_STUDY_OUTPUT_DIR}/baseline_controllers_tactis_quantile_head_cp_awaken/"
+exit ${EXIT_CODE}

--- a/whoc/case_studies/initialize_case_studies.py
+++ b/whoc/case_studies/initialize_case_studies.py
@@ -490,6 +490,57 @@ case_studies = {
         "target_turbine_indices": {"group": 1, "vals": ["74,73", "74,73", "4,"]},
         "model_key": {"group": 2, "vals": ["tactis"]},  #
     },
+    "baseline_controllers_tactis_quantile_head_cp_awaken": {
+        # Phase 7 — controller validation of the quantile-head TACTiS-2 model with CP
+        # stddev calibration. 4 arms x 30 wind seeds. Arms 1 vs 2 are the controlled
+        # head-to-head (identical except cp_calibrate_stddev); arms 3-4 are baselines.
+        "n_horizon": {"group": 0, "vals": [0]},
+        "controller_dt": {"group": 0, "vals": [5]},
+        "use_upstream_wind": {"group": 0, "vals": [True]},
+        "filter_floris_wind": {"group": 0, "vals": [False]},
+        "use_lut_filtered_wind_mag": {"group": 0, "vals": [True]},
+        "interpolation_method": {"group": 0, "vals": ["nearest"]},
+        "simulation_dt": {"group": 0, "vals": [1]},
+        # explicit checkpoint path (not "latest") — the quantile-head production checkpoint
+        "model_checkpoint": {
+            "group": 0,
+            "vals": [
+                "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/"
+                "train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/"
+                "manual_save_epoch99.ckpt"
+            ],
+        },
+        "floris_input_file": {"group": 0, "vals": ["../../examples/inputs/gch_KP_v4.yaml"]},
+        "lut_path": {"group": 0, "vals": ["../../examples/inputs/gch_KP_v4_lut.csv"]},
+        "yaw_limits": {"group": 0, "vals": ["-15,15"]},
+        "wind_forecast_class": {"group": 0, "vals": ["MLForecast"]},
+        "controller_class": {
+            "group": 1,
+            "vals": [
+                "LookupBasedWakeSteeringController",  # arm 1: uncertain, raw stddev
+                "LookupBasedWakeSteeringController",  # arm 2: uncertain, CP-calibrated stddev
+                "LookupBasedWakeSteeringController",  # arm 3: deterministic LUT baseline
+                "GreedyController",                   # arm 4: no-wake-steering floor
+            ],
+        },
+        "model_config_path": {
+            "group": 1,
+            "vals": [
+                "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml",
+                "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml",
+                "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml",
+                "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml",
+            ],
+        },
+        "prediction_timedelta": {"group": 1, "vals": [60, 60, 60, 60]},
+        "uncertain": {"group": 1, "vals": [True, True, False, False]},
+        # THE SWEEP — group 1 so arm i pairs element-wise with controller_class[i] etc.
+        # arm1 raw (False), arm2 CP-calibrated (True); arm3 uncertain=False so sd_* unused,
+        # arm4 GreedyController has no forecaster consuming sd_* — both inert.
+        "cp_calibrate_stddev": {"group": 1, "vals": [False, True, False, False]},
+        "target_turbine_indices": {"group": 1, "vals": ["74,73", "74,73", "74,73", "4,"]},
+        "model_key": {"group": 2, "vals": ["tactis"]},
+    },
     "baseline_controllers_baseline_det_forecasters_awaken": {
         "n_horizon": {"group": 0, "vals": [0]},
         "controller_dt": {"group": 0, "vals": [5]},
@@ -2242,4 +2293,5 @@ case_families = [
     "baseline_controllers_informer_forecaster_test_awaken",
     "baseline_controllers_svr_forecaster_test_awaken",  # 26, 27
     "control_signal_test_awaken",
-]  # 28
+    "baseline_controllers_tactis_quantile_head_cp_awaken",  # 29
+]  # 29

--- a/whoc/case_studies/run_case_studies.py
+++ b/whoc/case_studies/run_case_studies.py
@@ -180,6 +180,29 @@ if __name__ == "__main__":
         logging.info(f"Resetting args.n_seeds to {len(wind_field_ts)}")
         args.n_seeds = len(wind_field_ts)
 
+        # The tid2idx_mapping built above guesses turbine ids from the
+        # preprocessing config: with a single turbine_signature it uses
+        # turbine_mapping[0].keys() (e.g. "wt074"), but with multiple
+        # signatures it falls back to turbine_mapping[0].values() (the
+        # integer ids "74"). The DataModule, however, always names columns
+        # with turbine_signature[0]'s convention, so wind_field_ts here has
+        # columns like "ws_horz_wt074". Rebuild tid2idx_mapping from those
+        # actual columns so downstream f"ws_horz_{tid}" lookups resolve.
+        if args.wf_source == "scada" and tid2idx_mapping is not None:
+            ws_horz_suffixes = sorted(
+                (c[len("ws_horz_"):] for c in wind_field_ts[0].columns
+                 if c.startswith("ws_horz_")),
+                key=lambda s: int(re.search(r"\d+", s).group()),
+            )
+            rebuilt = {sfx: i for i, sfx in enumerate(ws_horz_suffixes)}
+            if rebuilt != tid2idx_mapping:
+                logging.info(
+                    f"Rebuilt tid2idx_mapping from wind_field_ts columns: "
+                    f"{list(tid2idx_mapping.items())[:2]}... -> "
+                    f"{list(rebuilt.items())[:2]}... ({len(rebuilt)} turbines)"
+                )
+                tid2idx_mapping = rebuilt
+
     if args.multiprocessor == "mpi":
         comm.Barrier()
 

--- a/whoc/wind_forecast/cp_scale_factors/quantile_head.json
+++ b/whoc/wind_forecast/cp_scale_factors/quantile_head.json
@@ -1,0 +1,30 @@
+{
+  "description": "CP stddev scale factors \u2014 multiply raw predictive stddev by scale_factors[component][lead_step] to get a CP-calibrated stddev.",
+  "source": "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/cp_phase0i_g_results_20260513/calibrated_intervals.parquet",
+  "alpha": 0.1,
+  "generated_at": "2026-05-14 12:54:49",
+  "components": [
+    "ws_horz",
+    "ws_vert"
+  ],
+  "lead_steps": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "scale_factors": {
+    "ws_horz": [
+      3.775924,
+      4.422153,
+      4.648451,
+      4.45615
+    ],
+    "ws_vert": [
+      5.024126,
+      5.877024,
+      6.234354,
+      6.051771
+    ]
+  }
+}

--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -79,9 +79,16 @@ class MLForecast(WindForecast):
                 "cp_scale_factors_path",
                 os.path.join(os.path.dirname(__file__), "cp_scale_factors", "quantile_head.json"),
             )
-            with open(cp_path) as f:
-                self.cp_scale_factors = json.load(f)["scale_factors"]
-            logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
+            with open(cp_path, encoding="utf-8") as f:
+                self.cp_scale_factors = json.load(f).get("scale_factors")
+            if self.cp_scale_factors is None:
+                logging.warning(
+                    f"CP scale factors file {cp_path} has no 'scale_factors' key; "
+                    f"disabling CP stddev calibration."
+                )
+                self.cp_calibrate_stddev = False
+            else:
+                logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
 
         # don't need this, can load hyperparamas from checkpoint
         # if self.use_tuned_params:
@@ -659,8 +666,8 @@ class MLForecast(WindForecast):
             factors = self.cp_scale_factors.get(base)
             if factors is None:
                 continue
-            for lead in range(min(n_leads, len(factors))):
-                mult[lead, c] = factors[lead]
+            n_copy = min(n_leads, len(factors))
+            mult[:n_copy, c] = torch.as_tensor(factors[:n_copy], device=device, dtype=dtype)
         return mult
 
     def predict_distr(self, historic_measurements: Union[pd.DataFrame, pl.DataFrame], current_time):

--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -2,6 +2,7 @@ from typing import Union
 from dataclasses import dataclass
 import os
 import re
+import json
 import types
 
 import inspect
@@ -64,6 +65,23 @@ class MLForecast(WindForecast):
         self.model_config = self.kwargs["model_config"]
         self.device = None
         self.resample = self.kwargs.get("resample", True)  # Default to True if not specified
+
+        # CP stddev calibration — opt-in. When enabled, predict_distr multiplies the
+        # raw per-component predictive stddev by a per-(lead, component) Conformal
+        # Prediction scale factor so downstream controllers receive calibrated
+        # stddevs. Default OFF: the scale factors are checkpoint-specific, so a case
+        # study must explicitly set cp_calibrate_stddev=True (and optionally point
+        # cp_scale_factors_path at a non-default table).
+        self.cp_calibrate_stddev = self.kwargs.get("cp_calibrate_stddev", False)
+        self.cp_scale_factors = None
+        if self.cp_calibrate_stddev:
+            cp_path = self.kwargs.get(
+                "cp_scale_factors_path",
+                os.path.join(os.path.dirname(__file__), "cp_scale_factors", "quantile_head.json"),
+            )
+            with open(cp_path) as f:
+                self.cp_scale_factors = json.load(f)["scale_factors"]
+            logging.info(f"CP stddev calibration ENABLED from {cp_path}: {self.cp_scale_factors}")
 
         # don't need this, can load hyperparamas from checkpoint
         # if self.use_tuned_params:
@@ -627,6 +645,24 @@ class MLForecast(WindForecast):
         else:
             return pred_df.to_pandas()
 
+    def _cp_multiplier(self, components, n_leads, device, dtype):
+        """Per-(lead, component) CP scale-factor tensor of shape [n_leads, len(components)].
+
+        `components` may be bare prefixes (``"ws_horz"``) or turbine-suffixed
+        (``"ws_horz_wt042"``) — the ``_wtNNN`` suffix is stripped so all turbines of a
+        component share that component's per-lead factors. Components absent from the
+        scale-factor table (or leads beyond its length) stay at 1.0 (no calibration).
+        """
+        mult = torch.ones((n_leads, len(components)), device=device, dtype=dtype)
+        for c, comp in enumerate(components):
+            base = comp.rsplit("_wt", 1)[0] if "_wt" in comp else comp
+            factors = self.cp_scale_factors.get(base)
+            if factors is None:
+                continue
+            for lead in range(min(n_leads, len(factors))):
+                mult[lead, c] = factors[lead]
+        return mult
+
     def predict_distr(self, historic_measurements: Union[pd.DataFrame, pl.DataFrame], current_time):
 
         if isinstance(historic_measurements, pd.DataFrame):
@@ -682,6 +718,10 @@ class MLForecast(WindForecast):
                         )  # .to(self.predictor.device)
                         pred_list[p].distribution.mean = samples_tensor.mean(dim=0)
                         pred_list[p].distribution.stddev = samples_tensor.std(dim=0)
+                        if self.cp_calibrate_stddev and self.cp_scale_factors is not None:
+                            sd = pred_list[p].distribution.stddev  # [n_leads, n_components]
+                            pred_list[p].distribution.stddev = sd * self._cp_multiplier(
+                                self.data_module.target_prefixes, sd.shape[0], sd.device, sd.dtype)
 
                 pred_df = pl.concat(
                     [
@@ -721,6 +761,10 @@ class MLForecast(WindForecast):
                     samples_tensor = torch.from_numpy(pred.samples)  # .to(self.predictor.device)
                     pred.distribution.mean = samples_tensor.to(self.predictor.device).mean(dim=0)
                     pred.distribution.stddev = samples_tensor.std(dim=0)
+                    if self.cp_calibrate_stddev and self.cp_scale_factors is not None:
+                        sd = pred.distribution.stddev  # [n_leads, n_all_target_cols]
+                        pred.distribution.stddev = sd * self._cp_multiplier(
+                            self.data_module.target_cols, sd.shape[0], sd.device, sd.dtype)
 
                 pred_df = pl.DataFrame(
                     data={

--- a/whoc/wind_forecast/ml_forecast.py
+++ b/whoc/wind_forecast/ml_forecast.py
@@ -115,7 +115,7 @@ class MLForecast(WindForecast):
                 f"Loaded checkpoint from {checkpoint_path}"
             )  # with hparams: {checkpoint_hparams}")
             self.data_module = DataModule(
-                data_path=self.model_config["dataset"]["data_path"],
+                normalized_data_path=self.model_config["dataset"]["data_path"],
                 n_splits=self.model_config["dataset"]["n_splits"],
                 continuity_groups=None,
                 train_split=(

--- a/whoc/wind_forecast/run_forecaster_validation.py
+++ b/whoc/wind_forecast/run_forecaster_validation.py
@@ -933,6 +933,14 @@ if __name__ == "__main__":
         default=None,
         type=int,
     )
+    parser.add_argument(
+        "--cp_calibrate_stddev",
+        action="store_true",
+        help="If set, MLForecast.predict_distr multiplies its raw predictive stddev "
+        "by the committed CP scale factors (whoc/wind_forecast/cp_scale_factors/quantile_head.json) "
+        "so sd_ws_horz_* / sd_ws_vert_* columns in the validation parquet are calibrated. "
+        "Default OFF — calibration is opt-in per run.",
+    )
     args = parser.parse_args()
 
     assert args.model is None or all(
@@ -1395,6 +1403,7 @@ if __name__ == "__main__":
                             study_name=None,  # db_setup_params["study_name"],
                             model_config=mncf,
                             resample=False,
+                            cp_calibrate_stddev=args.cp_calibrate_stddev,
                         ),
                         target_turbine_indices=args.target_turbine_indices,
                     )

--- a/whoc/wind_forecast/run_forecaster_validation.py
+++ b/whoc/wind_forecast/run_forecaster_validation.py
@@ -1060,7 +1060,7 @@ if __name__ == "__main__":
     joint_cgs = set()
     for mcnf in model_configs:
         data_module = DataModule(
-            data_path=mcnf["dataset"]["data_path"],
+            normalized_data_path=mcnf["dataset"]["data_path"],
             normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
             use_normalization=False,
             n_splits=1,  # model_config["dataset"]["n_splits"],

--- a/whoc/wind_forecast/tests/verify_cp_calibration.py
+++ b/whoc/wind_forecast/tests/verify_cp_calibration.py
@@ -1,0 +1,255 @@
+"""End-to-end verification of the CP stddev calibration in MLForecast.predict_distr.
+
+Builds TWO forecasters from the SAME quantile-head TACTiS-2 checkpoint:
+  - f_off : cp_calibrate_stddev not set (default OFF) — current behaviour
+  - f_on  : cp_calibrate_stddev=True — multiplies raw sd_* by the per-(lead,
+            component) CP scale factor from cp_scale_factors/quantile_head.json
+
+Both run predict_distr on the SAME context window with the SAME torch seed, so
+the only difference between their sd_* outputs is the calibration multiply.
+
+Assertions:
+  A  flag OFF is unchanged    — f_off sd_* median ~0.73 m/s (matches the known
+                                predict_sample oracle from verify_predict_distr_faithful.py)
+  B  flag ON = raw x scale    — for every (lead, component): f_on.sd / f_off.sd
+                                ~= scale_factors[component][lead]  (within 1e-3)
+  C  magnitude is sane        — f_on sd_* median ~3-4 m/s; horz < vert
+  D  lead structure preserved — f_on per-lead mean sd rises from lead 0 to lead 2
+                                (guards against a lead/component axis transpose)
+
+Run on a GPU node.
+"""
+import json
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import torch
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("verify-cp")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+SCALE_TABLE = "/user/taed7566/Forecasting/wind-hybrid-open-controller/whoc/wind_forecast/cp_scale_factors/quantile_head.json"
+SEED = 42
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        r = fn()
+        STAGES.append((name, "PASS", ""))
+        return r
+    except Exception as e:
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, traceback.format_exc())
+        raise
+
+
+def main():
+    from whoc.wind_forecast.ml_forecast import MLForecast
+    from wind_forecasting.preprocessing.data_module import DataModule
+
+    with open(MODEL_CONFIG) as f:
+        mcnf = yaml.safe_load(f)
+    scale_factors = json.load(open(SCALE_TABLE))["scale_factors"]
+    log.info("scale_factors = %s", scale_factors)
+
+    measurements_timedelta = pd.Timedelta(seconds=15)
+    ptd = pd.Timedelta(seconds=mcnf["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=mcnf["dataset"]["context_length"])
+
+    # --- test DataModule, faithful to run_forecaster_validation.py:1062 ---
+    def build_test_dm():
+        dm = DataModule(
+            normalized_data_path=mcnf["dataset"]["data_path"],
+            normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
+            use_normalization=False,
+            n_splits=1,
+            continuity_groups=None,
+            train_split=(1.0 - mcnf["dataset"]["val_split"] - mcnf["dataset"]["test_split"]),
+            val_split=mcnf["dataset"]["val_split"],
+            test_split=mcnf["dataset"]["test_split"],
+            prediction_length=mcnf["dataset"]["prediction_length"],
+            context_length=mcnf["dataset"]["context_length"],
+            target_prefixes=["ws_horz", "ws_vert"],
+            feat_dynamic_real_prefixes=["nd_cos", "nd_sin"],
+            freq=f"{int(measurements_timedelta.total_seconds())}s",
+            target_suffixes=mcnf["dataset"]["target_turbine_ids"],
+            per_turbine_target=False,
+            as_lazyframe=True,
+            dtype=pl.Float32,
+        )
+        dm.generate_splits(save=True, reload=False, splits=["test"])
+        return dm
+
+    test_dm = stage("Build test DataModule + generate_splits(test)", build_test_dm)
+
+    def build_test_data():
+        test_df = test_dm.datasets["test"]
+        if hasattr(test_df, "collect"):
+            test_df = test_df.collect()
+        rename_map = {
+            **{f"target_{i}": c for i, c in enumerate(test_dm.target_cols)},
+            **{f"feat_dynamic_real_{i}": c
+               for i, c in enumerate(test_dm.feat_dynamic_real_cols)},
+        }
+        return (test_df.rename(rename_map)
+                       .with_columns(continuity_group=pl.col("item_id")
+                                     .str.extract(r"SPLIT(\d+)").cast(int)))
+
+    test_data = stage("Load + rename cached test split", build_test_data)
+
+    # --- two forecasters from the same checkpoint: calibration OFF and ON ---
+    def make_forecaster(cp_on):
+        kwargs = dict(model_key="tactis", model_checkpoint=CHECKPOINT,
+                      optuna_storage=None, study_name=None,
+                      model_config=mcnf, resample=False)
+        if cp_on:
+            kwargs["cp_calibrate_stddev"] = True
+            kwargs["cp_scale_factors_path"] = SCALE_TABLE
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=max(pd.Timedelta(5, unit="s"), measurements_timedelta),
+            prediction_timedelta=ptd, context_timedelta=ctd,
+            fmodel=None, true_wind_field=None,
+            tid2idx_mapping={str(s): i for i, s in enumerate(test_dm.target_suffixes)},
+            turbine_signature=r"\d+", use_tuned_params=True,
+            kwargs=kwargs, target_turbine_indices=None,
+        )
+
+    f_off = stage("Construct MLForecast (calibration OFF)", lambda: make_forecaster(False))
+    f_on = stage("Construct MLForecast (calibration ON)", lambda: make_forecaster(True))
+    stage("reset() both forecasters", lambda: (f_off.reset(), f_on.reset()))
+
+    # sanity: f_on actually loaded the table, f_off did not
+    assert f_on.cp_calibrate_stddev and f_on.cp_scale_factors is not None, "f_on did not load scale factors"
+    assert not f_off.cp_calibrate_stddev, "f_off should have calibration disabled"
+
+    def pick_context():
+        n_ctx = f_off.n_context
+        sizes = (test_data.group_by("continuity_group").agg(pl.len().alias("n"))
+                 .sort("n", descending=True))
+        cg = sizes["continuity_group"][0]
+        sub = (test_data.filter(pl.col("continuity_group") == cg)
+                        .sort("time").head(n_ctx + 20).drop("continuity_group"))
+        for extra in ("item_id", "feat_static_cat", "prediction_timedelta"):
+            if extra in sub.columns:
+                sub = sub.drop(extra)
+        log.info("context cg=%s rows=%d current_time=%s", cg, sub.height, sub["time"][-1])
+        return sub, sub["time"][-1]
+
+    ctx, current_time = stage("Pick continuity group + context window", pick_context)
+
+    # --- run predict_distr on both, same seed so samples match ---
+    def run_off():
+        torch.manual_seed(SEED)
+        torch.cuda.manual_seed_all(SEED)
+        return f_off.predict_distr(ctx, current_time)
+
+    def run_on():
+        torch.manual_seed(SEED)
+        torch.cuda.manual_seed_all(SEED)
+        return f_on.predict_distr(ctx, current_time)
+
+    pred_off = stage("predict_distr — calibration OFF", run_off)
+    pred_on = stage("predict_distr — calibration ON", run_on)
+
+    # --- compare ---
+    def compare():
+        sd_cols = [c for c in pred_off.columns if c.startswith("sd_")]
+        assert sd_cols, "no sd_* columns in pred_off"
+        assert set(sd_cols) == set(c for c in pred_on.columns if c.startswith("sd_")), \
+            "sd_* column sets differ between OFF and ON"
+        n_leads = pred_off.height
+        log.info("sd_* columns: %d, prediction rows (leads): %d", len(sd_cols), n_leads)
+
+        off = pred_off.sort("time")
+        on = pred_on.sort("time")
+        off_arr = off.select(sd_cols).to_numpy()   # [n_leads, n_sd_cols]
+        on_arr = on.select(sd_cols).to_numpy()
+
+        # Assertion A — flag OFF unchanged: median ~0.73 m/s (the known oracle)
+        off_med = float(np.nanmedian(off_arr))
+        log.info("[A] f_off sd_* median = %.4f m/s (expect ~0.73, the predict_sample oracle)", off_med)
+        a_ok = 0.5 < off_med < 1.1
+
+        # Assertion B — flag ON = raw x per-(lead,component) scale factor
+        max_rel_err = 0.0
+        for j, col in enumerate(sd_cols):
+            comp = "ws_horz" if "ws_horz" in col else "ws_vert"
+            factors = np.array(scale_factors[comp][:n_leads])
+            expected = off_arr[:, j] * factors
+            got = on_arr[:, j]
+            denom = np.where(np.abs(expected) > 1e-9, np.abs(expected), 1.0)
+            rel = np.abs(got - expected) / denom
+            max_rel_err = max(max_rel_err, float(np.nanmax(rel)))
+        log.info("[B] max relative error of f_on vs f_off x scale = %.2e (expect < 1e-3)", max_rel_err)
+        b_ok = max_rel_err < 1e-3
+
+        # Assertion C — magnitude sane: f_on median ~3-4 m/s; horz < vert
+        on_med = float(np.nanmedian(on_arr))
+        horz_cols = [j for j, c in enumerate(sd_cols) if "ws_horz" in c]
+        vert_cols = [j for j, c in enumerate(sd_cols) if "ws_vert" in c]
+        horz_med = float(np.nanmedian(on_arr[:, horz_cols]))
+        vert_med = float(np.nanmedian(on_arr[:, vert_cols]))
+        log.info("[C] f_on sd_* median = %.4f m/s  (horz=%.4f, vert=%.4f)", on_med, horz_med, vert_med)
+        c_ok = (2.0 < on_med < 5.0) and (horz_med < vert_med)
+
+        # Assertion D — lead structure preserved: per-lead mean rises lead0->lead2
+        per_lead_mean = np.nanmean(on_arr, axis=1)  # [n_leads]
+        log.info("[D] f_on per-lead mean sd = %s", np.round(per_lead_mean, 4).tolist())
+        d_ok = per_lead_mean[0] < per_lead_mean[min(2, n_leads - 1)]
+
+        log.info("-" * 60)
+        log.info("[A] flag OFF unchanged (median ~0.73)        : %s", a_ok)
+        log.info("[B] flag ON == raw x scale (<1e-3 rel err)   : %s", b_ok)
+        log.info("[C] magnitude sane (~3-4 m/s, horz<vert)     : %s", c_ok)
+        log.info("[D] lead structure preserved (rises 0->2)    : %s", d_ok)
+        return dict(a=a_ok, b=b_ok, c=c_ok, d=d_ok,
+                    off_med=off_med, on_med=on_med, horz_med=horz_med,
+                    vert_med=vert_med, max_rel_err=max_rel_err)
+
+    return stage("COMPARE calibration OFF vs ON", compare)
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        result = main()
+    except Exception:
+        ok = False
+        result = None
+
+    print("\n" + "=" * 70)
+    print("CP CALIBRATION VERIFICATION REPORT")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        print(f"  [{status}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and result:
+        print(f"f_off sd median : {result['off_med']:.4f} m/s")
+        print(f"f_on  sd median : {result['on_med']:.4f} m/s  (horz {result['horz_med']:.3f}, vert {result['vert_med']:.3f})")
+        print(f"max rel err (ON vs raw x scale): {result['max_rel_err']:.2e}")
+        print("-" * 70)
+        if all([result["a"], result["b"], result["c"], result["d"]]):
+            print("RESULT: CP calibration VERIFIED — A/B/C/D all pass.")
+            sys.exit(0)
+        print("RESULT: CP calibration FAILED — see A/B/C/D above.")
+        sys.exit(2)
+    print("RESULT: harness failed before comparison — see failed stage above.")
+    sys.exit(1)

--- a/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
@@ -1,0 +1,280 @@
+"""FAITHFUL verification: predict_distr vs predict_sample on identical real input.
+
+Doubts being tested empirically:
+  1. Does predict_distr produce a non-empty df with loc_*/sd_* columns?  (structural)
+  2. Are the sd_* values HEALTHY (not collapsed to ~0)?                  (value sanity)
+  3. Does predict_distr's sd_* MATCH predict_sample's empirical sample
+     std on the SAME input?  predict_sample is the known-good oracle —
+     job 16929835 produced healthy spread (F^-1 width 2.09) through it.
+
+Faithful to the real pipeline (run_forecaster_validation.py:1062-1162):
+  - data: the cached test split, DENORMALIZED (raw m/s), 15s, all-turbine
+  - measurements_timedelta = 15s  (SBATCH used --simulation_timestep 15)
+  - input format: wide, turbine-suffixed columns (ws_horz_wtNNN ...)
+
+If predict_sample stays healthy but predict_distr collapses -> real predict_distr bug.
+If both collapse -> input still wrong.  If both healthy and ~equal -> predict_distr verified.
+"""
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("faithful")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+# The cached test split the real validation harness uses — denormalized, 15s, all-turbine.
+TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        r = fn()
+        STAGES.append((name, "PASS", ""))
+        return r
+    except Exception as e:
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, traceback.format_exc())
+        raise
+
+
+def main():
+    from whoc.wind_forecast.ml_forecast import MLForecast
+    from wind_forecasting.preprocessing.data_module import DataModule
+
+    with open(MODEL_CONFIG) as f:
+        mcnf = yaml.safe_load(f)
+
+    measurements_timedelta = pd.Timedelta(seconds=15)  # SBATCH --simulation_timestep 15
+    ptd = pd.Timedelta(seconds=mcnf["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=mcnf["dataset"]["context_length"])
+
+    # --- Stage 1: build the test_data DataModule exactly like run_forecaster_validation.py:1062
+    def build_test_dm():
+        dm = DataModule(
+            normalized_data_path=mcnf["dataset"]["data_path"],
+            normalization_consts_path=mcnf["dataset"]["normalization_consts_path"],
+            use_normalization=False,                       # DENORMALIZED — raw m/s
+            n_splits=1,
+            continuity_groups=None,
+            train_split=(1.0 - mcnf["dataset"]["val_split"] - mcnf["dataset"]["test_split"]),
+            val_split=mcnf["dataset"]["val_split"],
+            test_split=mcnf["dataset"]["test_split"],
+            prediction_length=mcnf["dataset"]["prediction_length"],
+            context_length=mcnf["dataset"]["context_length"],
+            target_prefixes=["ws_horz", "ws_vert"],
+            feat_dynamic_real_prefixes=["nd_cos", "nd_sin"],
+            freq=f"{int(measurements_timedelta.total_seconds())}s",   # "15s"
+            target_suffixes=mcnf["dataset"]["target_turbine_ids"],
+            per_turbine_target=False,                      # all-turbine wide format
+            as_lazyframe=True,
+            dtype=pl.Float32,
+        )
+        dm.generate_splits(save=True, reload=False, splits=["test"])
+        log.info("target_cols[:4]=%s ... (%d total)", dm.target_cols[:4], len(dm.target_cols))
+        log.info("feat_dynamic_real_cols[:2]=%s ... (%d total)",
+                 dm.feat_dynamic_real_cols[:2], len(dm.feat_dynamic_real_cols))
+        return dm
+
+    test_dm = stage("Build test DataModule + generate_splits(test)", build_test_dm)
+
+    # --- Stage 2: load + rename the test split into the wide format predict_* expect
+    def build_test_data():
+        test_df = test_dm.datasets["test"]
+        if hasattr(test_df, "collect"):
+            test_df = test_df.collect()
+        rename_map = {
+            **{f"target_{i}": c for i, c in enumerate(test_dm.target_cols)},
+            **{f"feat_dynamic_real_{i}": c
+               for i, c in enumerate(test_dm.feat_dynamic_real_cols)},
+        }
+        test_df = (test_df.rename(rename_map)
+                          .with_columns(continuity_group=pl.col("item_id")
+                                        .str.extract(r"SPLIT(\d+)").cast(int)))
+        log.info("test_data rows=%d, n continuity groups=%d",
+                 test_df.height, test_df["continuity_group"].n_unique())
+        return test_df
+
+    test_data = stage("Load + rename cached test split", build_test_data)
+
+    # --- Stage 3: construct MLForecast
+    def build_forecaster():
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=max(pd.Timedelta(5, unit="s"), measurements_timedelta),
+            prediction_timedelta=ptd,
+            context_timedelta=ctd,
+            fmodel=None,
+            true_wind_field=None,
+            tid2idx_mapping={str(s): i for i, s in enumerate(test_dm.target_suffixes)},
+            turbine_signature=r"\d+",
+            use_tuned_params=True,
+            kwargs=dict(model_key="tactis", model_checkpoint=CHECKPOINT,
+                        optuna_storage=None, study_name=None,
+                        model_config=mcnf, resample=False),
+            target_turbine_indices=None,
+        )
+
+    forecaster = stage("Construct MLForecast", build_forecaster)
+    stage("forecaster.reset()", lambda: forecaster.reset())
+
+    # --- Stage 4: pick a continuity group + build a context window
+    def pick_context():
+        n_ctx = forecaster.n_context
+        sizes = (test_data.group_by("continuity_group").agg(pl.len().alias("n"))
+                 .sort("n", descending=True))
+        cg = sizes["continuity_group"][0]
+        log.info("largest continuity_group=%s has %d rows (n_context=%d)",
+                 cg, sizes["n"][0], n_ctx)
+        sub = (test_data.filter(pl.col("continuity_group") == cg)
+                        .sort("time")
+                        .head(n_ctx + 20)
+                        .drop("continuity_group"))
+        # drop non-measurement columns predict_* don't expect
+        for extra in ("item_id", "feat_static_cat", "prediction_timedelta"):
+            if extra in sub.columns:
+                sub = sub.drop(extra)
+        current_time = sub["time"][-1]
+        log.info("context rows=%d, current_time=%s, cols sample=%s",
+                 sub.height, current_time, sub.columns[:5])
+        return sub, current_time
+
+    ctx, current_time = stage("Pick continuity group + context window", pick_context)
+
+    # --- Stage 5: predict_sample (ORACLE) on this exact input
+    def run_sample():
+        pred = forecaster.predict_sample(ctx, current_time, n_samples=200)
+        log.info("predict_sample -> rows=%d, cols=%d, n_samples=%d, n_times=%d",
+                 pred.height, len(pred.columns),
+                 pred["sample"].n_unique(), pred["time"].n_unique())
+        return pred
+
+    samp = stage("predict_sample (oracle)", run_sample)
+
+    # --- Stage 6: predict_distr on the SAME input
+    def run_distr():
+        pred = forecaster.predict_distr(ctx, current_time)
+        assert pred is not None and pred.height > 0, "predict_distr returned empty"
+        log.info("predict_distr -> rows=%d, cols=%d, n_times=%d",
+                 pred.height, len(pred.columns), pred["time"].n_unique())
+        return pred
+
+    distr = stage("predict_distr (under test)", run_distr)
+
+    # --- Stage 7: COMPARE oracle vs predict_distr
+    def compare():
+        # turbine-component columns present in the sample output
+        wt_cols = [c for c in samp.columns
+                   if c.startswith("ws_horz_") or c.startswith("ws_vert_")]
+        # empirical std from predict_sample, per (time, turbine-component)
+        emp = (samp.group_by("time")
+                   .agg([pl.col(c).std().alias(f"emp_sd_{c}") for c in wt_cols])
+                   .sort("time"))
+        # align times via JOIN (not set+is_in — polars is_in fails silently on
+        # datetime-precision mismatch). Cast both to ns first so the join keys match.
+        d = distr.with_columns(pl.col("time").cast(pl.Datetime("ns"))).sort("time")
+        e = emp.with_columns(pl.col("time").cast(pl.Datetime("ns"))).sort("time")
+        joined = d.join(e, on="time", how="inner").sort("time")
+        log.info("common prediction timestamps (via join): %d", joined.height)
+        assert joined.height > 0, "no overlapping timestamps between sample and distr"
+
+        # collect all sd_* from distr and emp_sd_* from oracle, matched by column
+        ratios, distr_sds, oracle_sds = [], [], []
+        for c in wt_cols:
+            sd_col = f"sd_{c}"
+            emp_col = f"emp_sd_{c}"
+            if sd_col not in joined.columns or emp_col not in joined.columns:
+                continue
+            dv = joined[sd_col].to_numpy().astype(float)
+            ev = joined[emp_col].to_numpy().astype(float)
+            distr_sds.append(dv)
+            oracle_sds.append(ev)
+            mask = ev > 1e-9
+            ratios.append(dv[mask] / ev[mask])
+
+        distr_sds = np.concatenate(distr_sds)
+        oracle_sds = np.concatenate(oracle_sds)
+        ratios = np.concatenate(ratios) if ratios else np.array([np.nan])
+
+        log.info("-" * 60)
+        log.info("predict_distr  sd_*  : median=%.5f  mean=%.5f  p10=%.5f  p90=%.5f  max=%.5f",
+                 np.median(distr_sds), distr_sds.mean(),
+                 np.quantile(distr_sds, .1), np.quantile(distr_sds, .9), distr_sds.max())
+        log.info("predict_sample emp_sd: median=%.5f  mean=%.5f  p10=%.5f  p90=%.5f  max=%.5f",
+                 np.median(oracle_sds), oracle_sds.mean(),
+                 np.quantile(oracle_sds, .1), np.quantile(oracle_sds, .9), oracle_sds.max())
+        log.info("ratio distr/oracle   : median=%.4f  mean=%.4f  (1.0 == perfect match)",
+                 np.median(ratios), np.mean(ratios))
+        log.info("-" * 60)
+
+        # VERDICTS
+        oracle_healthy = np.median(oracle_sds) > 0.1   # m/s — known-good path should be wide
+        distr_healthy = np.median(distr_sds) > 0.1
+        distr_matches_oracle = 0.5 < np.median(ratios) < 2.0
+
+        log.info("oracle (predict_sample) healthy (median sd > 0.1 m/s): %s", oracle_healthy)
+        log.info("predict_distr healthy (median sd > 0.1 m/s):           %s", distr_healthy)
+        log.info("predict_distr matches oracle (0.5 < ratio < 2.0):      %s", distr_matches_oracle)
+
+        return dict(
+            distr_sd_median=float(np.median(distr_sds)),
+            oracle_sd_median=float(np.median(oracle_sds)),
+            ratio_median=float(np.median(ratios)),
+            oracle_healthy=bool(oracle_healthy),
+            distr_healthy=bool(distr_healthy),
+            distr_matches_oracle=bool(distr_matches_oracle),
+        )
+
+    result = stage("COMPARE predict_distr vs predict_sample oracle", compare)
+    return result
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        result = main()
+    except Exception:
+        ok = False
+        result = None
+
+    print("\n" + "=" * 70)
+    print("FAITHFUL VERIFICATION REPORT — predict_distr vs predict_sample oracle")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        print(f"  [{status}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and result:
+        print(f"predict_distr  sd median : {result['distr_sd_median']:.5f} m/s")
+        print(f"predict_sample sd median : {result['oracle_sd_median']:.5f} m/s  (oracle)")
+        print(f"ratio (distr/oracle)     : {result['ratio_median']:.4f}")
+        print("-" * 70)
+        if result["oracle_healthy"] and result["distr_healthy"] and result["distr_matches_oracle"]:
+            print("RESULT: predict_distr VERIFIED — healthy spread, matches the oracle.")
+            sys.exit(0)
+        elif result["oracle_healthy"] and not result["distr_healthy"]:
+            print("RESULT: REAL predict_distr BUG — oracle is healthy but predict_distr collapsed.")
+            sys.exit(2)
+        elif not result["oracle_healthy"]:
+            print("RESULT: INCONCLUSIVE — even the oracle collapsed; input still not faithful.")
+            sys.exit(3)
+        else:
+            print("RESULT: predict_distr runs + healthy but does NOT match oracle — investigate scaling.")
+            sys.exit(4)
+    else:
+        print("RESULT: harness failed before comparison — see failed stage above.")
+        sys.exit(1)

--- a/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_faithful.py
@@ -33,8 +33,7 @@ sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
 
 MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
 CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
-# The cached test split the real validation harness uses — denormalized, 15s, all-turbine.
-TEST_PARQUET = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/DATA/preprocessed_awaken_data/awaken_processed_unsmoothed_normalized_train_ready_15s_all_turbine_ctx80_pred4_test_denormalize.parquet"
+# Note: the cached test split is loaded via the DataModule (build_test_dm), not a direct path.
 
 STAGES = []
 

--- a/whoc/wind_forecast/tests/verify_predict_distr_phase0i_g.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_phase0i_g.py
@@ -1,0 +1,210 @@
+"""Verify MLForecast.predict_distr works end-to-end with the Phase 0i-G checkpoint.
+
+Phase 0i-G validation (job 16929835) exercised predict_sample. The controller
+simulation path (simulate_case_studies) uses predict_distr instead, which is a
+separate code path that emits loc_* / sd_* columns. This script constructs the
+real MLForecast object the same way run_forecaster_validation.py does, feeds it
+a real slice of context data, calls predict_distr, and audits the output.
+
+Run on a GPU node:
+    python verify_predict_distr_phase0i_g.py
+"""
+import logging
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("verify")
+
+sys.path.insert(0, "/fs/dss/home/taed7566/Forecasting/pytorch-transformer-ts")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-hybrid-open-controller")
+sys.path.insert(0, "/user/taed7566/Forecasting/wind-forecasting")
+
+MODEL_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/training/training_inputs_storm_awaken_unsmoothed_pred60_tactis_phase0i_g.yaml"
+DATA_CONFIG = "/user/taed7566/Forecasting/wind-forecasting/config/preprocessing/preprocessing_inputs_awaken_STORM.yaml"
+CHECKPOINT = "/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/train_phase0i_g_quantile_pinball_tactis/20260512_101511_0_0/manual_save_epoch99.ckpt"
+
+STAGES = []
+
+
+def stage(name, fn):
+    log.info("=" * 70)
+    log.info("STAGE: %s", name)
+    log.info("=" * 70)
+    try:
+        result = fn()
+        STAGES.append((name, "PASS", ""))
+        return result
+    except Exception as e:
+        tb = traceback.format_exc()
+        STAGES.append((name, "FAIL", f"{type(e).__name__}: {e}"))
+        log.error("STAGE FAILED: %s\n%s", name, tb)
+        raise
+
+
+def main():
+    # fmodel is a stored dataclass field only — never referenced by MLForecast.__init__
+    # or predict_distr — so we pass None and skip the FLORIS dependency entirely.
+    from whoc.wind_forecast.ml_forecast import MLForecast
+
+    with open(MODEL_CONFIG) as f:
+        model_config = yaml.safe_load(f)
+    with open(DATA_CONFIG) as f:
+        data_config = yaml.safe_load(f)
+
+    # --- replicate run_forecaster_validation.py turbine wiring ---
+    sig = data_config.get("turbine_signature")
+    if isinstance(sig, list):
+        turbine_signature = sig[0] if len(sig) == 1 else r"\d+"
+    else:
+        turbine_signature = sig or r"\d+"
+
+    tmap = data_config.get("turbine_mapping")
+    if isinstance(tmap, list) and tmap:
+        keys = list(tmap[0].keys()) if len(data_config.get("turbine_signature", [1])) == 1 else list(tmap[0].values())
+        tid2idx_mapping = {str(k): i for i, k in enumerate(keys)}
+    else:
+        # fallback: derive from the data parquet's ws_horz_* columns
+        cols = pl.scan_parquet(model_config["dataset"]["data_path"]).collect_schema().names()
+        wt_ids = [c.replace("ws_horz_", "") for c in cols if c.startswith("ws_horz_")]
+        tid2idx_mapping = {str(k): i for i, k in enumerate(wt_ids)}
+    log.info("turbine_signature=%r, n turbines in tid2idx=%d", turbine_signature, len(tid2idx_mapping))
+
+    measurements_timedelta = pd.Timedelta(seconds=15)
+    controller_timedelta = max(pd.Timedelta(5, unit="s"), measurements_timedelta)
+    ptd = pd.Timedelta(seconds=model_config["dataset"]["prediction_length"])
+    ctd = pd.Timedelta(seconds=model_config["dataset"]["context_length"])
+
+    def build_forecaster():
+        return MLForecast(
+            measurements_timedelta=measurements_timedelta,
+            controller_timedelta=controller_timedelta,
+            prediction_timedelta=ptd,
+            context_timedelta=ctd,
+            fmodel=None,
+            true_wind_field=None,
+            tid2idx_mapping=tid2idx_mapping,
+            turbine_signature=turbine_signature,
+            use_tuned_params=True,
+            kwargs=dict(
+                model_key="tactis",
+                model_checkpoint=CHECKPOINT,
+                optuna_storage=None,
+                study_name=None,
+                model_config=model_config,
+                resample=False,
+            ),
+            target_turbine_indices=None,
+        )
+
+    forecaster = stage("Construct MLForecast (loads Phase 0i-G checkpoint)", build_forecaster)
+
+    stage("forecaster.reset()", lambda: forecaster.reset())
+
+    # --- build a real context window of historic measurements ---
+    def load_context():
+        # LAZY scan — never materialize the full multi-GB parquet.
+        # IMPORTANT: awaken_processed_unsmoothed_normalized.parquet is at 1-SECOND
+        # resolution, but the model was trained on 15-SECOND data (data_module.freq).
+        # predict_distr / _generate_test_data expect input already at the model freq.
+        # So we resample 1s -> 15s by mean (matches the training preprocessing)
+        # before handing it over — exactly what the real validation pipeline feeds in.
+        n_ctx = forecaster.n_context  # 80 steps at 15s
+        model_freq = str(forecaster.data_module.freq)  # "15s"
+        lf = pl.scan_parquet(model_config["dataset"]["data_path"])
+        first_cg = lf.select("continuity_group").head(1).collect()["continuity_group"][0]
+        # grab enough 1s rows to build n_ctx+margin 15s rows
+        n_raw = (n_ctx + 25) * 15
+        raw = (lf.filter(pl.col("continuity_group") == first_cg)
+                 .sort("time")
+                 .head(n_raw)
+                 .collect()
+                 .drop("continuity_group"))
+        log.info("raw 1s rows pulled: %d (continuity_group=%s)", raw.height, first_cg)
+        # resample 1s -> model freq by mean
+        sub = (raw.sort("time")
+                  .group_by_dynamic("time", every=model_freq)
+                  .agg(pl.all().mean()))
+        if sub.height < n_ctx + 1:
+            raise RuntimeError(
+                f"after 1s->{model_freq} resample only {sub.height} rows, need >= {n_ctx + 1}"
+            )
+        # Mirror make_predictions' contract: predict_distr receives rows with
+        # time <= current_time, so current_time = the LAST resampled timestamp.
+        current_time = sub["time"][-1]
+        step = (sub["time"][1] - sub["time"][0])
+        log.info("resampled to %s: rows=%d, step=%s, n_context=%d, current_time=%s",
+                 model_freq, sub.height, step, n_ctx, current_time)
+        return sub, current_time
+
+    hist, current_time = stage("Load real context window", load_context)
+
+    # --- the actual test: call predict_distr ---
+    def run_predict_distr():
+        pred = forecaster.predict_distr(hist, current_time)
+        return pred
+
+    pred = stage("CALL predict_distr", run_predict_distr)
+
+    # --- audit the output ---
+    def audit():
+        assert pred is not None and pred.height > 0, "empty prediction"
+        cols = pred.columns
+        loc_cols = [c for c in cols if c.startswith("loc_")]
+        sd_cols = [c for c in cols if c.startswith("sd_")]
+        log.info("output rows=%d, cols=%d", pred.height, len(cols))
+        log.info("  loc_* columns: %d (e.g. %s)", len(loc_cols), loc_cols[:3])
+        log.info("  sd_*  columns: %d (e.g. %s)", len(sd_cols), sd_cols[:3])
+        assert len(sd_cols) > 0, "NO sd_* columns produced — controller would have no stddev input"
+        assert len(loc_cols) > 0, "NO loc_* columns produced"
+        # NaN / negativity / magnitude checks on sd_*
+        sd_arr = pred.select(sd_cols).to_numpy()
+        loc_arr = pred.select(loc_cols).to_numpy()
+        n_nan_sd = int(np.isnan(sd_arr).sum())
+        n_neg_sd = int((sd_arr < 0).sum())
+        n_nan_loc = int(np.isnan(loc_arr).sum())
+        log.info("  sd_* : NaN=%d, negative=%d, min=%.4f, median=%.4f, max=%.4f",
+                 n_nan_sd, n_neg_sd, np.nanmin(sd_arr), np.nanmedian(sd_arr), np.nanmax(sd_arr))
+        log.info("  loc_*: NaN=%d, min=%.4f, median=%.4f, max=%.4f",
+                 n_nan_loc, np.nanmin(loc_arr), np.nanmedian(loc_arr), np.nanmax(loc_arr))
+        assert n_nan_sd == 0, f"{n_nan_sd} NaN values in sd_* columns"
+        assert n_neg_sd == 0, f"{n_neg_sd} negative values in sd_* columns"
+        assert n_nan_loc == 0, f"{n_nan_loc} NaN values in loc_* columns"
+        # the prediction horizon should be prediction_length steps
+        log.info("  prediction timestamps: %d (expect ~%d)",
+                 pred["time"].n_unique(), int(ptd / measurements_timedelta))
+        return dict(rows=pred.height, loc_cols=len(loc_cols), sd_cols=len(sd_cols),
+                    sd_median=float(np.nanmedian(sd_arr)))
+
+    summary = stage("Audit predict_distr output", audit)
+    return summary
+
+
+if __name__ == "__main__":
+    ok = True
+    try:
+        summary = main()
+    except Exception:
+        ok = False
+        summary = None
+
+    print("\n" + "=" * 70)
+    print("VERIFICATION REPORT — predict_distr on Phase 0i-G checkpoint")
+    print("=" * 70)
+    for name, status, detail in STAGES:
+        mark = "PASS" if status == "PASS" else "FAIL"
+        print(f"  [{mark}] {name}" + (f"  — {detail}" if detail else ""))
+    print("=" * 70)
+    if ok and summary:
+        print(f"RESULT: predict_distr WORKS with Phase 0i-G.")
+        print(f"  output rows={summary['rows']}, loc_* cols={summary['loc_cols']}, "
+              f"sd_* cols={summary['sd_cols']}, sd median={summary['sd_median']:.4f}")
+        sys.exit(0)
+    else:
+        print("RESULT: predict_distr FAILED — see failed stage above.")
+        sys.exit(1)

--- a/whoc/wind_forecast/tests/verify_predict_distr_quantile_head.py
+++ b/whoc/wind_forecast/tests/verify_predict_distr_quantile_head.py
@@ -1,13 +1,13 @@
-"""Verify MLForecast.predict_distr works end-to-end with the Phase 0i-G checkpoint.
+"""Verify MLForecast.predict_distr works end-to-end with the quantile-head TACTiS-2 checkpoint.
 
-Phase 0i-G validation (job 16929835) exercised predict_sample. The controller
-simulation path (simulate_case_studies) uses predict_distr instead, which is a
-separate code path that emits loc_* / sd_* columns. This script constructs the
+The quantile-head model's validation (job 16929835) exercised predict_sample. The
+controller simulation path (simulate_case_studies) uses predict_distr instead, which
+is a separate code path that emits loc_* / sd_* columns. This script constructs the
 real MLForecast object the same way run_forecaster_validation.py does, feeds it
 a real slice of context data, calls predict_distr, and audits the output.
 
 Run on a GPU node:
-    python verify_predict_distr_phase0i_g.py
+    python verify_predict_distr_quantile_head.py
 """
 import logging
 import sys
@@ -102,7 +102,7 @@ def main():
             target_turbine_indices=None,
         )
 
-    forecaster = stage("Construct MLForecast (loads Phase 0i-G checkpoint)", build_forecaster)
+    forecaster = stage("Construct MLForecast (loads quantile-head checkpoint)", build_forecaster)
 
     stage("forecaster.reset()", lambda: forecaster.reset())
 
@@ -194,14 +194,14 @@ if __name__ == "__main__":
         summary = None
 
     print("\n" + "=" * 70)
-    print("VERIFICATION REPORT — predict_distr on Phase 0i-G checkpoint")
+    print("VERIFICATION REPORT — predict_distr on quantile-head checkpoint")
     print("=" * 70)
     for name, status, detail in STAGES:
         mark = "PASS" if status == "PASS" else "FAIL"
         print(f"  [{mark}] {name}" + (f"  — {detail}" if detail else ""))
     print("=" * 70)
     if ok and summary:
-        print(f"RESULT: predict_distr WORKS with Phase 0i-G.")
+        print(f"RESULT: predict_distr WORKS with the quantile-head checkpoint.")
         print(f"  output rows={summary['rows']}, loc_* cols={summary['loc_cols']}, "
               f"sd_* cols={summary['sd_cols']}, sd median={summary['sd_median']:.4f}")
         sys.exit(0)

--- a/whoc/wind_forecast/tools/build_cp_scale_table.py
+++ b/whoc/wind_forecast/tools/build_cp_scale_table.py
@@ -1,0 +1,111 @@
+"""Build the CP stddev scale-factor table consumed by MLForecast.predict_distr.
+
+The TACTiS-2 model's raw predictive standard deviations are honest in shape but
+under-confident: at the 90% nominal level the raw bands cover only ~56% of the
+truth. Conformal Prediction (CQR) bands cover >=90% by construction. The ratio
+of the CP band width to the raw band width is therefore a multiplicative
+correction factor for the raw stddev.
+
+This script aggregates that factor from a `calibrated_intervals.parquet`
+(produced by wind-forecasting's apply_cp_to_phase0i_b.py) down to a small
+per-(lead_step, component) table — 4 leads x 2 components = 8 numbers. Turbine-
+to-turbine variation in the factor has a coefficient of variation of only ~0.2,
+so aggregating over turbines captures the two axes that genuinely matter
+(forecast horizon and wind component) without overfitting one validation slice.
+
+Run once, offline:
+    python build_cp_scale_table.py \\
+        --intervals <cp_results_dir>/calibrated_intervals.parquet \\
+        --output    ../cp_scale_factors/quantile_head.json \\
+        --alpha 0.1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("build-cp-scale")
+
+# component prefixes — must match MLForecast.data_module.target_prefixes
+COMPONENTS = ["ws_horz", "ws_vert"]
+_TARGET_RE = re.compile(r"^(ws_horz|ws_vert)_wt\d+$")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--intervals", type=Path, required=True,
+                    help="calibrated_intervals.parquet from the CP pipeline")
+    ap.add_argument("--output", type=Path, required=True,
+                    help="destination JSON (e.g. ../cp_scale_factors/quantile_head.json)")
+    ap.add_argument("--alpha", type=float, default=0.1,
+                    help="confidence level to build the table at (default 0.1 = 90% nominal)")
+    args = ap.parse_args()
+
+    log.info("Loading %s", args.intervals)
+    ci = pl.read_parquet(args.intervals).filter(pl.col("alpha") == args.alpha)
+    if ci.height == 0:
+        raise SystemExit(f"No rows with alpha == {args.alpha} in {args.intervals}")
+    log.info("  rows at alpha=%s: %d", args.alpha, ci.height)
+
+    # per-row CP scale factor: (cp band width) / (raw band width), guarded
+    ci = ci.with_columns([
+        (pl.col("upper_cp") - pl.col("lower_cp")).alias("cp_w"),
+        (pl.col("upper_raw") - pl.col("lower_raw")).alias("raw_w"),
+    ])
+    ci = ci.with_columns(
+        pl.when(pl.col("raw_w") > 1e-9)
+          .then(pl.col("cp_w") / pl.col("raw_w"))
+          .otherwise(None)  # degenerate (zero-range) targets -> dropped from the mean
+          .alias("scale")
+    )
+    # component from target_col (e.g. "ws_horz_wt042" -> "ws_horz")
+    ci = ci.with_columns(
+        pl.col("target_col").str.extract(r"^(ws_horz|ws_vert)_wt\d+$", 1).alias("component")
+    )
+    n_bad = ci.filter(pl.col("component").is_null()).height
+    if n_bad:
+        log.warning("  %d rows had a target_col not matching ws_(horz|vert)_wtNNN — dropped", n_bad)
+    ci = ci.drop_nulls(["scale", "component"])
+
+    leads = sorted(ci["lead_step"].unique().to_list())
+    log.info("  lead steps present: %s", leads)
+
+    scale_factors = {c: [] for c in COMPONENTS}
+    log.info("Per-(lead, component) aggregate (mean scale, CoV across turbines+time):")
+    for comp in COMPONENTS:
+        for lead in leads:
+            sub = ci.filter((pl.col("component") == comp) & (pl.col("lead_step") == lead))["scale"]
+            arr = sub.to_numpy()
+            mean = float(np.mean(arr))
+            cov = float(np.std(arr) / mean) if mean != 0 else float("nan")
+            scale_factors[comp].append(round(mean, 6))
+            log.info("  %s lead %d : mean=%.4f  CoV=%.3f  (n=%d)", comp, lead, mean, cov, arr.size)
+
+    out = {
+        "description": (
+            "CP stddev scale factors — multiply raw predictive stddev by "
+            "scale_factors[component][lead_step] to get a CP-calibrated stddev."
+        ),
+        "source": str(args.intervals),
+        "alpha": args.alpha,
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "components": COMPONENTS,
+        "lead_steps": leads,
+        "scale_factors": scale_factors,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2) + "\n")
+    log.info("Wrote %s", args.output)
+    log.info("scale_factors = %s", json.dumps(scale_factors))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Integrates CP (Conformalized Quantile Regression) scale-factor calibration into `MLForecast.predict_distr` so the `sd_ws_horz_*` / `sd_ws_vert_*` columns the controller (or any consumer) sees are auto-calibrated when the flag is on — no per-call code or post-processing required.

Addresses Aoife's request to integrate the stddev logic into BOTH the `make_predictions` flow (in `run_forecaster_validation.py`) and `predict_distr` (in `MLForecast`). Because `make_predictions` consumes `predict_distr`'s output, fixing the latter auto-fixes the former — no separate code path.

Also adds the Phase 7 controller-validation case study (case 29, 4 arms × 30 seeds: raw stddev / CP-calibrated / deterministic LUT / GreedyController) plus the few bug fixes needed for it to actually run on Storm.

## How to enable CP calibration

There are two consumer paths and the flag plumbs into each through a different surface — both are now wired:

### A. Offline forecaster validation (`run_forecaster_validation.py`)

Pass `--cp_calibrate_stddev` on the command line:
```bash
python whoc/wind_forecast/run_forecaster_validation.py \
    --model tactis \
    --model_config <path-to-phase0i_g-training-yaml> \
    --data_config <path-to-preprocessing-yaml> \
    --checkpoint <ckpt-path-or-"latest"> \
    --prediction_type distribution \
    --save_dir <output-dir> \
    --max_splits N \
    --rerun_validation \
    --cp_calibrate_stddev      # opt-in; default OFF
```

### B. Live controller validation (`simulate_case_studies` via `run_case_studies.py`)

Set in the wcnf — at the TOP level of `wind_forecast:` (NOT nested under `MLForecast:`):
```yaml
wind_forecast:
  cp_calibrate_stddev: true   # MUST be top-level here
  context_timedelta: 600
  ...
```
Or per-case in a case-study dict (see `initialize_case_studies.py:540` for the pattern).

Both paths produce the log line `CP stddev calibration ENABLED from .../quantile_head.json: {...}` exactly once per MLForecast instantiation — the canonical sanity check.

## Empirical proof — LIVE run

Job 17001215 (running on cfdg002, started 2026-05-15 17:10) — arm 2 only logged:
```
CP stddev calibration ENABLED from .../quantile_head.json:
  {'ws_horz': [3.776, 4.422, 4.648, 4.456],
   'ws_vert': [5.024, 5.877, 6.234, 6.052]}
```
Arms 1, 3, 4 stayed silent (raw stddev). `case_descriptions.csv` confirms the per-arm flag is zipped through the harness correctly.

## What changed

- `whoc/wind_forecast/ml_forecast.py` — opt-in `cp_calibrate_stddev` kwarg (default OFF); multiplies `pred.distribution.stddev` by the per-(lead, component) CP scale factors in both inference branches.
- `whoc/wind_forecast/run_forecaster_validation.py` — new `--cp_calibrate_stddev` CLI flag plumbed into the MLForecast kwargs dict.
- `whoc/wind_forecast/cp_scale_factors/quantile_head.json` — 8-number scale table from `calibrated_intervals.parquet` at α=0.1.
- `whoc/wind_forecast/tools/build_cp_scale_table.py` — table builder.
- `whoc/wind_forecast/tests/verify_cp_calibration.py` + 2 others — end-to-end ON/OFF verification.
- `examples/hercules_input_001.yaml` — registers `cp_calibrate_stddev: false` at top level of `wind_forecast:` (must be top-level — see the inline comment for the alphabetic-routing trap).
- `whoc/case_studies/initialize_case_studies.py` — case study 29 (4-arm sweep).
- `whoc/case_studies/bash_script_storm_gpu.sh` — Storm SBATCH (cf, ProcessPoolExecutor; sidesteps MPI ABI issues).
- `whoc/case_studies/run_case_studies.py` — rebuild `tid2idx_mapping` from the real `wind_field_ts` columns; fixes a ColumnNotFoundError with multi-`turbine_signature` configs (AWAKEN STORM).

## Test plan

- [x] `verify_predict_distr_quantile_head.py` — predict_distr matches predict_sample oracle to ~0.5%.
- [x] `verify_cp_calibration.py` — `f_on.sd == f_off.sd × scale` to ~8.4e-08.
- [x] Live: arm-2-only CP-ENABLED log line confirms per-case routing in `simulate_case_studies`.
- [ ] End-to-end head-to-head (FarmPower / yaw delta) — partial results within 24h on 17001215; full 30-seed run waits for cfdg.p resubmit after the GPFS maintenance window (May 20–27).
- [ ] Aoife's own `run_forecaster_validation.py --cp_calibrate_stddev` run to confirm calibrated `sd_*` columns in the validation parquet.

## Heads-up

`initialize_case_studies.py`'s routing loop iterates `sorted(case.items())` (alphabetic). The nested-MLForecast predicate check only fires if `wind_forecast_class` has already been processed THAT iteration. Any new wind-forecast param sorting BEFORE `wind_forecast_class` MUST live at the top of the wcnf's `wind_forecast:` block, not nested under `MLForecast:`, or it silently gets dropped. There's an explanatory comment at the new placement.
